### PR TITLE
Adding two new projects to the 'Third-Party Clients' section

### DIFF
--- a/docs/platform/02-client.md
+++ b/docs/platform/02-client.md
@@ -138,3 +138,6 @@ Here are some clients built by the community for various other languages:
 
 ## Go
 [Gage-Technologies](https://github.com/Gage-Technologies/mistral-go)
+
+## Ruby
+[gbaptista/mistral-ai](https://github.com/gbaptista/mistral-ai)

--- a/docs/platform/02-client.md
+++ b/docs/platform/02-client.md
@@ -136,6 +136,9 @@ curl --location "https://api.mistral.ai/v1/embeddings" \
 
 Here are some clients built by the community for various other languages:
 
+## CLI
+[icebaker/nano-bots](https://github.com/icebaker/ruby-nano-bots)
+
 ## Go
 [Gage-Technologies](https://github.com/Gage-Technologies/mistral-go)
 


### PR DESCRIPTION
Adding two new projects to the 'Third-Party Clients' section:

- Ruby Client: [gbaptista/mistral-ai](https://github.com/gbaptista/mistral-ai)
- CLI Multi-Provider Client: [icebaker/nano-bots](https://github.com/icebaker/ruby-nano-bots)