### PR TITLE
Add PHP Client to Third-Party Clients section

### DIFF
--- a/docs/platform/02-client.md
+++ b/docs/platform/02-client.md
@@ -144,3 +144,6 @@ Here are some clients built by the community for various other languages:
 
 ## Ruby
 [gbaptista/mistral-ai](https://github.com/gbaptista/mistral-ai)
+
+## PHP
+[HelgeSverre/mistral](https://github.com/HelgeSverre/mistral)


### PR DESCRIPTION
I've built a PHP Client and have added it to the list of third party clients.

Repo: https://github.com/HelgeSverre/mistral