### PR TITLE
Add a PHP client to the 'Third-Party Clients' section

### DIFF
--- a/docs/platform/02-client.md
+++ b/docs/platform/02-client.md
@@ -144,3 +144,6 @@ Here are some clients built by the community for various other languages:
 
 ## Ruby
 [gbaptista/mistral-ai](https://github.com/gbaptista/mistral-ai)
+
+## PHP
+[partITech/php-mistral](https://github.com/partITech/php-mistral)


### PR DESCRIPTION
Added an PHP client to the 'Third-Party Clients' section:

https://github.com/partITech/php-mistral