### PR TITLE
Adding security schemas to opeanapi spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -52,7 +52,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ModelList'
+security:
+  - ApiKeyAuth: []
 components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: http
+      scheme: "bearer"
   schemas:
     Error:
       type: object


### PR DESCRIPTION
Fixes #12 

Ensures that libraries know that the API uses bearer token authentication across all endpoints.