### PR TITLE
Adding a third party Java client - LangChain4j

### DIFF
--- a/docs/platform/02-client.md
+++ b/docs/platform/02-client.md
@@ -137,7 +137,7 @@ curl --location "https://api.mistral.ai/v1/embeddings" \
 Here are some clients built by the community for various other languages:
 
 ## Java
-[langchain4j/lanchain4j-mistral-ai](https://github.com/langchain4j/langchain4j)
+Mistral AI integration via [langchain4j](https://github.com/langchain4j/langchain4j)
 
 ## CLI
 [icebaker/nano-bots](https://github.com/icebaker/ruby-nano-bots)

--- a/docs/platform/02-client.md
+++ b/docs/platform/02-client.md
@@ -136,6 +136,9 @@ curl --location "https://api.mistral.ai/v1/embeddings" \
 
 Here are some clients built by the community for various other languages:
 
+## Java
+[langchain4j/lanchain4j-mistral-ai](https://github.com/langchain4j/langchain4j)
+
 ## CLI
 [icebaker/nano-bots](https://github.com/icebaker/ruby-nano-bots)
 


### PR DESCRIPTION
Hi @sophiamyang a LangChain4j is an popular open-source java project and recently added Mistral AI client support.