### PR TITLE
Add Rust client in Client code > Third-Party Clients section

### DIFF
--- a/docs/platform/02-client.md
+++ b/docs/platform/02-client.md
@@ -256,3 +256,6 @@ Here are some clients built by the community for various other languages:
 
 ## Ruby
 [gbaptista/mistral-ai](https://github.com/gbaptista/mistral-ai)
+
+## Rust
+[ivangabriele/mistralai-client-rs](https://github.com/ivangabriele/mistralai-client-rs)


### PR DESCRIPTION
Hi there ^^,

My lib is normally up to date since I just developed it tonight. I found a few undocumented props both in the responses and the official JS/Python clients that I chose to hide for now. I still need to implement the FC which I'll do in the next few days.

[![GitHub Release](https://img.shields.io/github/v/release/ivangabriele/mistralai-client-rs?style=for-the-badge#)](https://github.com/ivangabriele/mistralai-client-rs) [![Crates.io Package](https://img.shields.io/crates/v/mistralai-client?style=for-the-badge)](https://crates.io/crates/mistralai-client)

## Supported APIs

- [x] Chat without streaming
- [x] Chat without streaming (async)
- [x] Chat with streaming
- [x] Embedding
- [x] Embedding (async)
- [x] List models
- [x] List models (async)
- [x] Function Calling
- [x] Function Calling (async)

I also need to add inline documentation for Doc.rs.