### PR TITLE
Add the 1:1 port to Ruby of the official Python client to the client list

### DIFF
--- a/docs/getting-started/clients.mdx
+++ b/docs/getting-started/clients.mdx
@@ -76,3 +76,4 @@ Here are some clients built by the community for various other languages:
 
 ### Ruby
 [gbaptista/mistral-ai](https://github.com/gbaptista/mistral-ai)
+[wilsonsilva/mistral](https://github.com/wilsonsilva/mistral)


### PR DESCRIPTION
Hello. A few days ago, I released [a Ruby client](https://github.com/wilsonsilva/mistral). It is a 1:1 Python client port of the official client-python.

- It has API parity with the official Python client (https://github.com/mistralai/client-python)
- It is the only Ruby client with the exact same error handling, retry mechanisms and configuration options as the Python client
- It is the only Ruby client that __supports functions__
- It only has __two__ dependencies
- It is __fully typed__, avoiding primitive obsession
- It implements the same examples

Here's a brief implementation of chat stream using the official Python client and using my Ruby clent:

```python
client = MistralClient(api_key=os.environ["MISTRAL_API_KEY"])

response = client.chat_stream(
  model="mistral-small",
  messages=[ChatMessage(role="user", content="Hi")],
)

for chunk in response:
  print(chunk.choices[0].delta.content)
```

```ruby
client = Mistral::Client.new(api_key: ENV["MISTRAL_API_KEY"])

response = client.chat_stream(
  model: "mistral-small",
  messages: [Mistral::ChatMessage.new(role: "user", content: "Hi")]
)

for chunk in response do
  print(chunk.choices[0].delta.content)
end
```

The API is so similar that I'm sure that if you have any experience with the Python client, you will understand the Ruby version effortlessly.

And here's a blog post explaining how it compares with the two existing Ruby libraries: https://wilsonsilva.com/mistral-ruby-gem/