### PR TITLE
Add third party Dart client to the platform docs

### DIFF
--- a/docs/getting-started/clients.mdx
+++ b/docs/getting-started/clients.mdx
@@ -71,6 +71,9 @@ Here are some clients built by the community for various other languages:
 ### CLI
 [icebaker/nano-bots](https://github.com/icebaker/ruby-nano-bots)
 
+## Dart
+[nomtek/mistralai_client_dart](https://github.com/nomtek/mistralai_client_dart)
+
 ### Go
 [Gage-Technologies](https://github.com/Gage-Technologies/mistral-go)
 


### PR DESCRIPTION
This PR adds a Dart client to the platform docs under Third-Party Clients. It can be used in both pure Dart and Flutter applications.

Link to the official package repository page https://pub.dev/packages/mistralai_client_dart
Link to the Github page https://github.com/nomtek/mistralai_client_dart

This is the same PR as https://github.com/mistralai/platform-docs-public/pull/30 but I had to reopen it to fix merge conflicts.