### PR TITLE
Portkey open source Gateway integration with Codestral

### DIFF
--- a/docs/capabilities/code-generation.mdx
+++ b/docs/capabilities/code-generation.mdx
@@ -350,3 +350,28 @@ messages = [
 MistralAI(api_key=api_key, model=mistral_model).chat(messages)
 ```
 Check out more details in this [notebook](https://github.com/run-llama/llama_index/blob/main/docs/docs/examples/cookbooks/codestral.ipynb).
+
+## Integration with Portkey
+Portkey provides observability, reliability, and caching layer over Codestral Instruct. Here is how you can use it with Portkey: 
+
+```py
+# make sure to install `portkey-ai` in your Python enviornment
+
+import os
+from portkey_ai import Portkey
+
+portkey = Portkey(
+    api_key=os.environ["PORTKEY_API_KEY"],
+    provider="mistral-ai",
+    authorization="Bearer MISTRAL_API_KEY"
+)
+
+mistral_model = "codestral-latest"
+messages=[{"role": "user", "content": "Write a function for fibonacci"}]
+
+code_completion = portkey.chat.completions.create(
+    model=mistral_model,
+    messages=messages
+)
+```
+Check out more details in this [doc](https://portkey.ai/docs/welcome/integration-guides/mistral-ai).


### PR DESCRIPTION
Portkey natively integrates with Codestral Instruct on both the`codestral.mistral` and `api.mistral` URLs. Have showcased the `api.mistral` example here, and added the `codestral.mistral` example in the attached doc.

Portkey will give out-of-the-box observability over all Codestral requests and also help make the requests robust & reliable with features like fallbacks, load balancing, and more.