### PR TITLE
fix: correct typo in text generation guide

### DIFF
--- a/docs/capabilities/completion.mdx
+++ b/docs/capabilities/completion.mdx
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 The Mistral models allows you to chat with a model that has been fine-tuned to follow 
-instructions and respond to natural lanugage prompts. 
+instructions and respond to natural language prompts. 
 A prompt is the input that you provide to the Mistral model. 
 It can come in various forms, such as asking a question, giving an instruction, 
 or providing a few examples of the task you want the model to perform. 


### PR DESCRIPTION
Corrected "lanugage" to "language".