### PR TITLE
fix: correct typo in 'environment'

### DIFF
--- a/docs/capabilities/code-generation.mdx
+++ b/docs/capabilities/code-generation.mdx
@@ -316,7 +316,7 @@ In the Tabnine Chat App, use the [model selector](https://docs.tabnine.com/main/
 LangChain provides support for Codestral Instruct. Here is how you can use it in LangChain: 
 
 ```py
-# make sure to install `langchain` and `langchain-mistralai` in your Python enviornment
+# make sure to install `langchain` and `langchain-mistralai` in your Python environment
 
 import os
 from langchain_mistralai import ChatMistralAI


### PR DESCRIPTION
Corrected the typo in the word 'environment' within the LangChain integration example.