### PR TITLE
fix: Correct misspelling of "halluciation"

### DIFF
--- a/docs/getting-started/glossary.mdx
+++ b/docs/getting-started/glossary.mdx
@@ -52,7 +52,7 @@ retrieval systems. There are two main steps in RAG: 1) retrieval: retrieve relev
 embeddings stored in a vector store; 2) generation: insert the relevant information to the prompt for the LLM 
 to generate information. RAG is useful to answer questions or generate content leveraging external knowledge including
 up-to-date information and domain-specific information.
-RAG allows the model to access and utilize information beyond its training data, reducing halluciation and 
+RAG allows the model to access and utilize information beyond its training data, reducing hallucination and 
 improving factual accuracy. Check out our [Basic RAG](/guides/rag/) guide for details. 
 
 ## Fine-tuning


### PR DESCRIPTION
Corrected the misspelling of the word "hallucination" in the glossary entry for RAG. The previous text incorrectly spelled it as "halluciation."