### PR TITLE
Fix: typo "models allows" to "models allow" in documentation

### DIFF
--- a/docs/capabilities/completion.mdx
+++ b/docs/capabilities/completion.mdx
@@ -7,7 +7,7 @@ sidebar_position: 2.2
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-The Mistral models allows you to chat with a model that has been fine-tuned to follow 
+The Mistral models allow you to chat with a model that has been fine-tuned to follow 
 instructions and respond to natural language prompts. 
 A prompt is the input that you provide to the Mistral model. 
 It can come in various forms, such as asking a question, giving an instruction, 


### PR DESCRIPTION
Corrected a typo in the text generation documentation where "models allows" was changed to "models allow". This ensures grammatical accuracy and clarity in the description of Mistral models.