### PR TITLE
-fix: change "look of" to "look at" in embeddings guide

### DIFF
--- a/docs/capabilities/embeddings.mdx
+++ b/docs/capabilities/embeddings.mdx
@@ -39,7 +39,7 @@ EmbeddingResponse(
 )
 ```
 
-Let's take a look of the length of the first embedding:
+Let's take a look at the length of the first embedding:
 
 ```python
 len(embeddings_batch_response.data[0].embedding)


### PR DESCRIPTION
Corrected the phrase "Let's take a look of the length of the first embedding:" to "Let's take a look at the length of the first embedding:" in the embeddings guide.