### PR TITLE
fix: correct typo in paraphrase detection section

### DIFF
--- a/docs/capabilities/embeddings.mdx
+++ b/docs/capabilities/embeddings.mdx
@@ -91,7 +91,7 @@ In our example above, we used the Euclidean distance to measure the distance bet
 ## Paraphrase detection
 Another potential use case is paraphrase detection. In this simple example, we have a list of three sentences, and we would like to find out if any of the two sentences are paraphrases of each other. If the distance between two sentence embeddings is small, it suggests that the two sentences are semantically similar and could be potential paraphrases.
 
-Result suggests that the first two sentences are semantically similar and could be potential paraphrases, whereas the third sentence is more different. This is just a super simple example. But this approach can be extended to more complex situations in real-world applications, such as detecting paraphrases in social media posts, news articles, or customer reviews.
+The result suggests that the first two sentences are semantically similar and could be potential paraphrases, whereas the third sentence is more different. This is just a super simple example. But this approach can be extended to more complex situations in real-world applications, such as detecting paraphrases in social media posts, news articles, or customer reviews.
 
 ```python
 import itertools


### PR DESCRIPTION
Corrected the typo in the paraphrase detection section for clarity. The sentence now correctly reads: "The result suggests that the first two sentences are semantically similar and could be potential paraphrases, whereas the third sentence is more different." This ensures the description accurately reflects the semantic similarity between sentences.