### PR TITLE
Fix: Add hyphen to 'top-level' in feature description

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -28,7 +28,7 @@ const FeatureList: FeatureItem[] = [
     title: 'The best Open Source LLMs',
     description: (
       <>
-        Our top level team of researchers and engineers are working on the best open source models.
+        Our top-level team of researchers and engineers are working on the best open source models.
       </>
     ),
   },


### PR DESCRIPTION
Corrected the phrase "top level team of researchers" to "top-level team of researchers" by adding a hyphen for proper compound adjective usage. This ensures clarity and adherence to standard grammatical conventions.