### PR TITLE
Fix typo in Docusaurus configuration file

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -44,7 +44,7 @@ const config = {
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
 
-  // Even if you don't use internalization, you can use this field to set useful
+  // Even if you don't use internationalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want
   // to replace "en" with "zh-Hans".
   i18n: {


### PR DESCRIPTION
Corrected the spelling of "internalization" to "internationalization" in the Docusaurus configuration file to ensure proper terminology for setting metadata for different languages.