### PR TITLE
Fix typo in OpenAPI specification

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -714,7 +714,7 @@ components:
           nullable: true
           description: | 
             What sampling temperature to use, between 0.0 and 1.0. 
-            Higher values like 0.8 will make the outptu more random,
+            Higher values like 0.8 will make the output more random,
             while lower values like 0.2 will make it more focused and
             deterministic.
 


### PR DESCRIPTION
Corrected the spelling of "outptu" to "output" in the OpenAPI specification to ensure accurate documentation.