### PR TITLE
fix: typos in models documentation

### DIFF
--- a/docs/getting-started/models.mdx
+++ b/docs/getting-started/models.mdx
@@ -87,7 +87,7 @@ As a general rule, if you are new to using Large Language Models, you can always
 ### Use cases 
 
 ### Mistral Small: Simple tasks that one can do in bulk
-Mistral Small is the ideal choice for simpe tasks that one can do in builk - like Classification, Customer Support, or Text Generation. It offers excellent performance at an affordable price point. For instance, it can be effectively used for a classification task to classify if an email is spam or not: 
+Mistral Small is the ideal choice for simple tasks that one can do in bulk - like Classification, Customer Support, or Text Generation. It offers excellent performance at an affordable price point. For instance, it can be effectively used for a classification task to classify if an email is spam or not: 
 
 **Prompt:**
 ```
@@ -99,7 +99,7 @@ Classify the following email to determine if it is spam or not. Only respond wit
 Mistral Small, Mistral 8x22B, and Mistral Large all can accurately classify this email correctly as “Spam”. Mistral Small is capable to provide the correct classification as the larger models. So it is the most efficient and affordable choice for this kind of tasks. 
 
 ### Mistral 8x22B: Intermediate tasks that require language transformation
-Mistral 8x22B is the ideal for intermediate tasks that require moderate reasoning - like Data extraction, Summarizing a Document, Writing a Job Description, or Writing Product Descriptions. Mistral 8x22B strikes a balance between performance and capability, making it suitable for a wide range of tasks that only require language transformaion. For example, Mistral 8x22B can write an email:
+Mistral 8x22B is the ideal for intermediate tasks that require moderate reasoning - like Data extraction, Summarizing a Document, Writing a Job Description, or Writing Product Descriptions. Mistral 8x22B strikes a balance between performance and capability, making it suitable for a wide range of tasks that only require language transformation. For example, Mistral 8x22B can write an email:
 
 **Prompt:**
 ```
@@ -196,7 +196,7 @@ It may seem counterintuitive because we often think of iron as being a heavy mat
 
 - **Coding**
 
-Mistral Large, the top performer in coding tasks, is the ideal choice for users who priortize coding capabilities in their model selection. 
+Mistral Large, the top performer in coding tasks, is the ideal choice for users who prioritize coding capabilities in their model selection. 
 
 Here is an example of Mistral Large giving the correct code following the prompt. 
 


### PR DESCRIPTION
Corrected the following typos in the models documentation: 'simpe' to 'simple', 'builk' to 'bulk', 'transformaion' to 'transformation', and 'priortize' to 'prioritize'.