### PR TITLE
fix: grammatical error in La Plateforme documentation

### DIFF
--- a/docs/deployment/la-plateforme.mdx
+++ b/docs/deployment/la-plateforme.mdx
@@ -32,7 +32,7 @@ Explore the capabilities of our models:
 
 ### Cloud-based deployments
 
-For a comprehensive list of options to deploy and consume Mistral AI models on the cloud, head on to the **[cloud deployment section](/deployment/cloud/overview)**.
+For a comprehensive list of options to deploy and consume Mistral AI models on the cloud, head to the **[cloud deployment section](/deployment/cloud/overview)**.
 
 ### Raw model weights
 


### PR DESCRIPTION
Changed "head on to" to "head to" for improved clarity and correctness in the La Plateforme documentation. The phrase "head on to" is not grammatically correct in this context. "Head to" is more concise and widely accepted in English, ensuring better readability and comprehension for users.