### PR TITLE
fix: typo in function_calling guide

### DIFF
--- a/docs/capabilities/function-calling.mdx
+++ b/docs/capabilities/function-calling.mdx
@@ -142,7 +142,7 @@ How do Mistral models know about these functions and know which function to use?
 
 
 ### tool_choice
-Users can use `tool_choice` to speficy how tools are used:
+Users can use `tool_choice` to specify how tools are used:
 - "auto": default mode. Model decides if it uses the tool or not.
 - "any": forces tool use.
 - "none": prevents tool use.


### PR DESCRIPTION
Corrected the typo "speficy" to "specify" in the "Function Calling" guide.