### PR TITLE
docs: Remove extra space before question mark

### DIFF
--- a/docs/capabilities/code-generation.mdx
+++ b/docs/capabilities/code-generation.mdx
@@ -16,7 +16,7 @@ We currently offer two domains for Codestral endpoints, both providing FIM and i
 | codestral.mistral.ai | - Monthly subscription based, free until 1st of August <br/> - Has a rate limit of 30 requests per minute and a high daily limit of 2000 requests <br/> - Requires a new key for which a phone number is needed |
 | api.mistral.ai  | - Allows you to use your existing API key and you can pay to use Codestral <br/> - Ideal for business use <br/> - Provide higher rate limits of 200 requests per second per workspace |
 
-Wondering which endpoint to use ?
+Wondering which endpoint to use?
 - If you're a user, wanting to query Codestral as part of an IDE plugin, codestral.mistral.ai is recommended.
 - If you're building a plugin, or anything that exposes these endpoints directly to the user, and expect them to bring their own API keys, you should also target codestral.mistral.ai
 - For all other use cases, api.mistral.ai will be better suited


### PR DESCRIPTION
Fixed an extra space before the question mark in the endpoint usage section.