### PR TITLE
fix: improve contribution instructions

### DIFF
--- a/docs/guides/contribute.md
+++ b/docs/guides/contribute.md
@@ -14,10 +14,10 @@ Thank you for your interest in contributing to Mistral AI. We welcome everyone w
 If you are interested in contributing to our [official docs](https://docs.mistral.ai/), please submit a PR at [https://github.com/mistralai/platform-docs-public](https://github.com/mistralai/platform-docs-public). 
 
 You can easily help by:
-- fix a typo
-- clarify a section
-- document an underdocumented feature
-- update a section that should have been updated
+- fixing a typo
+- clarifying a section
+- documenting an underdocumented feature
+- updating a section that should have been updated
 - ... 
 
 ## Contributing to the code clients


### PR DESCRIPTION
Changed bullet points under "You can easily help by" section to use gerunds for consistency:

  - "fix a typo" to "fixing a typo"
  - "clarify a section" to "clarifying a section"
  - "document an underdocumented feature" to "documenting an underdocumented feature"
  - "update a section that should have been updated" to "updating a section that should have been updated"