### PR TITLE
Document omniai-mistral third-party client

### DIFF
--- a/docs/getting-started/clients.mdx
+++ b/docs/getting-started/clients.mdx
@@ -94,6 +94,7 @@ We recommend reaching out to the respective maintainers for any assistance or in
 ### Ruby
 [gbaptista/mistral-ai](https://github.com/gbaptista/mistral-ai)
 [wilsonsilva/mistral](https://github.com/wilsonsilva/mistral)
+[ksylvest/omniai-mistral](https://github.com/ksylvest/omniai-mistral)
 
 ### Rust
 [ivangabriele/mistralai-client-rs](https://github.com/ivangabriele/mistralai-client-rs)


### PR DESCRIPTION
Link to [omniai-mistral](https://github.com/ksylvest/omniai-mistral) under the third-party client section for ruby.