### PR TITLE
vllm for v3 tokenizer - self deployment

### DIFF
--- a/docs/deployment/self-deployment/vllm.mdx
+++ b/docs/deployment/self-deployment/vllm.mdx
@@ -25,9 +25,9 @@ On a GPU-enabled host, you can run the Mistral AI LLM Inference image with the f
 ```bash
 docker run --gpus all \
     -e HF_TOKEN=$HF_TOKEN -p 8000:8000 \
-    ghcr.io/mistralai/mistral-src/vllm:latest \
+    vllm/vllm-openai:latest \
     --host 0.0.0.0 \
-    --model mistralai/Mistral-7B-Instruct-v0.2
+    --model mistralai/Mistral-7B-Instruct-v0.3
 ```
 
   </TabItem>
@@ -36,7 +36,7 @@ docker run --gpus all \
 ```bash
 docker run --gpus all \
     -e HF_TOKEN=$HF_TOKEN -p 8000:8000 \
-    ghcr.io/mistralai/mistral-src/vllm:latest \
+    vllm/vllm-openai:latest \
     --host 0.0.0.0 \
     --model mistralai/Mixtral-8x7B-Instruct-v0.1 \
     --tensor-parallel-size 2 # adapt to your GPUs \
@@ -47,9 +47,9 @@ docker run --gpus all \
     ```bash
     docker run --gpus all \
         -e HF_TOKEN=$HF_TOKEN -p 8000:8000 \
-        ghcr.io/mistralai/mistral-src/vllm:latest \
+        vllm/vllm-openai:latest \
         --host 0.0.0.0 \
-        --model mistralai/Mixtral-8x22B-Instruct-v0.1 \
+        --model mistralai/Mixtral-8x22B-Instruct-v0.3 \
         --tensor-parallel-size 4 # adapt to your GPUs \
     ```
   </TabItem>
@@ -65,6 +65,7 @@ If your GPU has CUDA capabilities below 8.0, you will see the error `ValueError:
 :::
 
 The dockerfile for this image can be found on our [reference implementation github](https://github.com/mistralai/mistral-src/blob/main/deploy/Dockerfile).
+An example Docker compose file to deploy with vllm can be found at[community example](https://github.com/slabstech/docker/blob/master/docker_compose_files/llm/mistral-vllm.yml)
 
 ## Without docker
 
@@ -95,7 +96,7 @@ You can then use the following command to start the server:
 ```bash
 python -u -m vllm.entrypoints.openai.api_server \
        --host 0.0.0.0 \
-       --model mistralai/Mistral-7B-Instruct-v0.2
+       --model mistralai/Mistral-7B-Instruct-v0.3
 ```
   </TabItem>
   <TabItem value="mixtral8x7b" label="Mixtral-8X7B">
@@ -115,7 +116,7 @@ python -u -m vllm.entrypoints.openai.api_server \
 ```bash
 python -u -m vllm.entrypoints.openai.api_server \
        --host 0.0.0.0 \
-       --model mistralai/Mixtral-8X22B-Instruct-v0.1 \
+       --model mistralai/Mixtral-8X22B-Instruct-v0.3 \
        --tensor-parallel-size 4 # adapt to your GPUs \
 ```
 


### PR DESCRIPTION
Updated docs to reflect v3 tokenizer.
Note : vllm packages are outdated. 