### PR TITLE
Fix typo in JS Guardrailing

### DIFF
--- a/docs/capabilities/guardrailing.mdx
+++ b/docs/capabilities/guardrailing.mdx
@@ -26,7 +26,7 @@ chat_response = client.chat(
 const chatResponse = await client.chat(
     model: 'mistral-large-latest',
     messages: [{role: 'user', content: 'What is the best French cheese?'}],
-    safe_prompt: true
+    safePrompt: true
 );
 ```
   </TabItem>


### PR DESCRIPTION
👋, this fix is for a small typo in [Guardrailing section](https://docs.mistral.ai/capabilities/guardrailing/) for the Javascript library. 

```diff
const chatResponse = await client.chat(
    model: 'mistral-large-latest',
    messages: [{role: 'user', content: 'What is the best French cheese?'}],
-   safe_prompt: true
+   safePrompt: true
);
```