### PR TITLE
fix(typo): typo in responseFormat for NodeJs

### DIFF
--- a/docs/capabilities/json-mode.mdx
+++ b/docs/capabilities/json-mode.mdx
@@ -63,7 +63,7 @@ const mistral = new Mistral({apiKey: apiKey});
 const chatResponse = await mistral.chat.complete({
     model: "mistral-large-latest",
     messages: [{role: 'user', content: 'What is the best French meal? Return the name and the ingredients in JSON format.'}],
-    response_format: {type: 'json_object'},
+    responseFormat: {type: 'json_object'},
     }
 );
 


### PR DESCRIPTION
Fixed a typo in the responseFormat for Node.js in JSON mode section. 