### PR TITLE
Update models.mdx

### DIFF
--- a/docs/getting-started/models.mdx
+++ b/docs/getting-started/models.mdx
@@ -39,9 +39,9 @@ Mistral provides two types of models: free models and premier models.
 
 | Model               | Weight availability|Available via API| Description | Max Tokens| API Endpoints|Version|
 |--------------------|:--------------------:|:--------------------:|:--------------------:|:--------------------:|:--------------------:|:--------------------:|
-| Mistral 7B    | :heavy_check_mark: <br/> Apache2 |:heavy_check_mark: |Our best open source model to date released April 2024. Learn more on our [blog post](https://mistral.ai/news/announcing-mistral-7b/)| 32k | `open-mistral-7b`| v0.3|
+| Mistral 7B    | :heavy_check_mark: <br/> Apache2 |:heavy_check_mark: |Our first dense model released September 2023. Learn more on our [blog post](https://mistral.ai/news/announcing-mistral-7b/)| 32k | `open-mistral-7b`| v0.3|
 | Mixtral 8x7B  |:heavy_check_mark: <br/> Apache2 | :heavy_check_mark: |Our first sparse mixture-of-experts released December 2023. Learn more on our [blog post](https://mistral.ai/news/mixtral-of-experts/)| 32k  | `open-mixtral-8x7b`| v0.1|
-| Mixtral 8x22B  |:heavy_check_mark: <br/> Apache2 | :heavy_check_mark: |Our first dense model released September 2023. Learn more on our [blog post](https://mistral.ai/news/mixtral-8x22b/)| 64k  | `open-mixtral-8x22b`| v0.1|
+| Mixtral 8x22B  |:heavy_check_mark: <br/> Apache2 | :heavy_check_mark: |Our best open source model to date released April 2024. Learn more on our [blog post](https://mistral.ai/news/mixtral-8x22b/)| 64k  | `open-mixtral-8x22b`| v0.1|
 
 
 ## API versioning 


### PR DESCRIPTION
The table has the descriptions transposed between first and third row. This corrects the information. The links seem correct. 