### PR TITLE
docs: add SoftCreatR/php-mistral-ai-sdk

### DIFF
--- a/docs/getting-started/clients.mdx
+++ b/docs/getting-started/clients.mdx
@@ -98,6 +98,7 @@ We recommend reaching out to the respective maintainers for any assistance or in
 ### PHP
 [HelgeSverre/mistral](https://github.com/HelgeSverre/mistral)
 [partITech/php-mistral](https://github.com/partITech/php-mistral)
+[SoftCreatR/php-mistral-ai-sdk](https://github.com/SoftCreatR/php-mistral-ai-sdk)
 
 ### Ruby
 [gbaptista/mistral-ai](https://github.com/gbaptista/mistral-ai)


### PR DESCRIPTION
This PR adds the [SoftCreatR/php-mistral-ai-sdk](https://github.com/SoftCreatR/php-mistral-ai-sdk) to the clients page (as a 3rd Party PHP library)