### PR TITLE
restructure quickstart

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -9,25 +9,37 @@ import TabItem from '@theme/TabItem';
 
 [platform_url]: https://console.mistral.ai/
 
-
 :::tip[ ]
 Looking for La Plateforme? Head to [console.mistral.ai][platform_url]
 :::
 
-## Getting started with Mistral AI API
+## Getting started with the Mistral AI API
+
+The Mistral AI API provides a seamless way for you to integrate Mistral's
+state-of-the-art models into your applications and production workflows with
+just a few lines of code.
+Our API is currently available through [La Plateforme][platform_url].
 
 <a target="_blank" href="https://colab.research.google.com/github/mistralai/cookbook/blob/main/quickstart.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 
-Mistral AI API provides a seamless way for developers to integrate Mistral's state-of-the-art 
-models into their applications and production workflows with just a few lines of code. 
-Our API is currently available through [La Plateforme][platform_url]. 
-You need to activate payments on your account to enable your API keys.
+### Get an API key
+
+1. Go to [console.mistral.ai][platform_url] and sign in or create an account.
+2. In the **Billing** section of the left menu, click **Workspace**.
+3. Click **Go to to the billing plans page**, then select a plan.
+4. In the **API** section of the left menu, click **API Keys**.
+5. Click **Create new key**, then click **Create key** to confirm.
+6. Click **Copy**. Save the API key securely, and do not share it with anyone.
+
+### Try the Chat Completion API
+
 After a few moments, you will be able to use our `chat` endpoint:
 
 <Tabs>
   <TabItem value="python" label="python" default>
+
 ```python
 import os
 from mistralai import Mistral
@@ -52,6 +64,7 @@ print(chat_response.choices[0].message.content)
   </TabItem>
 
   <TabItem value="typescript" label="typescript">
+
 ```typescript
 import { Mistral } from '@mistralai/mistralai';
 
@@ -66,9 +79,11 @@ const chatResponse = await client.chat.complete({
 
 console.log('Chat:', chatResponse.choices[0].message.content);
 ```
+
   </TabItem>
 
   <TabItem value="curl" label="curl">
+  
 ```bash
 curl --location "https://api.mistral.ai/v1/chat/completions" \
      --header 'Content-Type: application/json' \
@@ -79,16 +94,20 @@ curl --location "https://api.mistral.ai/v1/chat/completions" \
     "messages": [{"role": "user", "content": "Who is the most renowned French painter?"}]
   }'
 ```
+
   </TabItem>
 </Tabs>
 
-To generate text embeddings using Mistral AI's embeddings API, we can make a request to the API 
-endpoint and specify the embedding model `mistral-embed`, along with providing a list of input texts. 
-The API will then return the corresponding embeddings as numerical vectors, which can be used for
-further analysis or processing in NLP applications.
+### Try the Embeddings API
+
+To generate text embeddings, you can make a request that specifies the model
+`mistral-embed` and includes a list of input texts.
+The API returns the corresponding embeddings as numerical vectors, which you can
+use for further analysis or processing in NLP applications.
 
 <Tabs>
   <TabItem value="python" label="python" default>
+  
 ```python
 import os
 from mistralai import Mistral
@@ -109,6 +128,7 @@ print(embeddings_response)
   </TabItem>
 
   <TabItem value="typescript" label="typescript">
+  
 ```typescript
 import { Mistral } from '@mistralai/mistralai';
 
@@ -123,9 +143,11 @@ const embeddingsResponse = await client.embeddings.create({
 
 console.log(embeddingsResponse);
 ```
+
   </TabItem>
 
   <TabItem value="curl" label="curl">
+  
 ```bash
 curl --location "https://api.mistral.ai/v1/embeddings" \
      --header 'Content-Type: application/json' \
@@ -136,16 +158,10 @@ curl --location "https://api.mistral.ai/v1/embeddings" \
     "input": ["Embed this sentence.", "As well as this one."]
   }'
 ```
+
   </TabItem>
 </Tabs>
 
+For a full description of the models offered by the API, see the
+**[Models Overview](../models/models_overview)**.
 
-
-For a full description of the models offered on the API, head on to the **[model documentation](../models/models_overview)**.
-
-## Account setup
-
-- To get started, create a Mistral account or sign in at [console.mistral.ai][platform_url].
-- Then, navigate to "Workspace" and "Billing" to add your payment information and activate payments on your account. 
-- After that, go to the "API keys" page and make a new API key by clicking "Create new key". 
-Make sure to copy the API key, save it safely, and do not share it with anyone.


### PR DESCRIPTION
Moved instructions for getting an API key to the beginning so that readers have what they need to try the code samples. 
Also made some minor markdown and content fixes.