### PR TITLE
Update link to the JupyterLite demo

### DIFF
--- a/docs/capabilities/code-generation.mdx
+++ b/docs/capabilities/code-generation.mdx
@@ -409,7 +409,7 @@ Afterwards, you can select Codestral as your model of choice, input your Mistral
 JupyterLite is a project that aims to bring the JupyterLab environment to the web browser, allowing users to run Jupyter directly in their browser without the need for a local installation.
 
 You can try Codestral with JupyterLite in your browser:
-[![lite-badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://jupyterlite.github.io/jupyterlab-codestral/lab/index.html)
+[![lite-badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://jupyterlite.github.io/ai/lab/index.html)
 
 <iframe width="560" height="315" width="100%" src="https://www.youtube.com/embed/edKyZSWy-Fw?si=pBzFV40vckyuCl6w" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 


### PR DESCRIPTION
There has been some progress lately on the former `jupyterlab-codestral` extension, which enables using Codestral in a Jupyter environment in the browser directly.

`jupyterlab-codestral` has been renamed to `@jupyterlite/ai` since it now supports other providers too.

It is still possible to configure it to use `MistralAI` as the provider:

![image](https://github.com/user-attachments/assets/0ae99888-a36e-45d0-932c-864b7cb8cb93)
