### PR TITLE
Update vision.md

### DIFF
--- a/docs/capabilities/vision.md
+++ b/docs/capabilities/vision.md
@@ -387,7 +387,7 @@ Model output:
   {'item_name': 'WH/SUB BSL - MUSH', 'price': 4},
   {'item_name': 'BURGER - MED WELL', 'price': 10},
   {'item_name': 'WH BREAD/NO ONION', 'price': 2},
-  {'item_name': 'SUB POUTINE - MUSH', 'price': 2},
+  {'item_name': 'SUB POUTINE - MUSH', 'price': 0},
   {'item_name': 'CHK PESTO/BR', 'price': 9},
   {'item_name': 'SUB POUTINE', 'price': 2},
   {'item_name': 'SPEC OMELET/BR', 'price': 9},


### PR DESCRIPTION
I'm wondering why this line:

`{'item_name': 'SUB POUTINE - MUSH', 'price': 2},`

![firefox_ldykfkscAp](https://github.com/user-attachments/assets/f09f2251-f06b-4196-880b-9dd4f826d9c1)

Have a price of "2" whereas there is not amount on the document.

The issue here is that the "total_price" in the JSON is incorrect (would be "70" not "68" with this "2" added by OCR recognition).