### PR TITLE
Feat/syncronizing tabs

### DIFF
--- a/docs/capabilities/batch.md
+++ b/docs/capabilities/batch.md
@@ -22,7 +22,7 @@ Here's an example of how to structure a batch request:
 
 Save your batch into a .jsonl file. Once saved, you can upload your batch input file to ensure it is correctly referenced when initiating batch processes: 
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 ```python
 from mistralai import Mistral
@@ -79,7 +79,7 @@ Create a new batch job, it will be queued for processing.
 - `endpoint`: we currently support `/v1/embeddings`, `/v1/chat/completions`, `/v1/fim/completions`, `/v1/moderations`, `/v1/chat/moderations`.
 - `metadata`: optional custom metadata for the batch.
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 ```python
 created_job = client.batch.jobs.create(
@@ -129,7 +129,7 @@ curl --location "https://api.mistral.ai/v1/batch/jobs" \
 
 ## Get a batch job details 
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 ```python
 retrieved_job = client.batch.jobs.get(job_id=created_job.id)
@@ -150,7 +150,7 @@ curl https://api.mistral.ai/v1/batch/jobs/<jobid> \
 </Tabs>
 
 ## Get batch job results
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 ```python
 client.files.download(file_id=retrieved_job.output_file)
@@ -177,7 +177,7 @@ You can view a list of your batch jobs and filter them by various criteria, incl
 `CANCELLED`
 - Metadata: custom metadata key and value for the batch
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 ```python
 list_job = client.batch.jobs.list(
@@ -208,7 +208,7 @@ curl 'https://api.mistral.ai/v1/batch/jobs?status=RUNNING&job_type=testing'\
 
 ## Request the cancellation of a batch job
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 ```python
 canceled_job = client.batch.jobs.cancel(job_id=created_job.id)

--- a/docs/capabilities/batch.md
+++ b/docs/capabilities/batch.md
@@ -55,7 +55,8 @@ const batchData = await client.files.upload({
     file: {
         fileName: "batch_input_file.jsonl",
         content: batchFile,
-    }
+    },
+    purpose: "batch"
 });
 ```
   </TabItem>

--- a/docs/capabilities/code-generation.mdx
+++ b/docs/capabilities/code-generation.mdx
@@ -38,7 +38,7 @@ This guide will walk you through how to use Codestral fill-in-the-middle endpoin
 With this feature, users can define the starting point of the code using a `prompt`, and the ending point of the code using an optional `suffix` and an optional `stop`. The Codestral model will then generate the code that fits in between, making it ideal for tasks that require a specific piece of code to be generated. Below are three examples:  
 
 #### Example 1: Fill in the middle
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 ```python
 import os
@@ -89,7 +89,7 @@ curl --location 'https://api.mistral.ai/v1/fim/completions' \
 </Tabs>
 
 #### Example 2: Completion
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 ```python
 import os
@@ -136,7 +136,7 @@ curl --location 'https://api.mistral.ai/v1/fim/completions' \
 We recommend adding stop tokens for IDE autocomplete integrations to prevent the model from being too verbose.
 :::
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 ```python
 import os
@@ -189,7 +189,7 @@ The only difference is the endpoint used:
 - Instruct endpoint: https://api.mistral.ai/v1/chat/completions
 
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 ```python
 import os
@@ -226,7 +226,7 @@ curl --location "https://api.mistral.ai/v1/chat/completions" \
 
 ## Codestral Mamba
 We have also released Codestral Mamba 7B, a Mamba2 language model specialized in code generation with the instruct endpoint. 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 ```python
 import os

--- a/docs/capabilities/finetuning.mdx
+++ b/docs/capabilities/finetuning.mdx
@@ -171,7 +171,7 @@ Once you have the data file with the right format,
 you can upload the data file to the Mistral Client, 
 making them available for use in fine-tuning jobs.
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 
 ```python
@@ -246,7 +246,7 @@ The next step is to create a fine-tuning job.
     - `auto_start=True`: Your job will be launched immediately after validation.
     - `auto_start=False` (default): You can manually start the training after validation by sending a POST request to `/fine_tuning/jobs/<uuid>/start`.
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 
 ```python
@@ -318,7 +318,7 @@ You can also list jobs, retrieve a job, or cancel a job.
 You can filter and view a list of jobs using various parameters such as 
 `page`, `page_size`, `model`, `created_after`, `created_by_me`, `status`, `wandb_project`, `wandb_name`, and `suffix`. Check out our [API specs](https://docs.mistral.ai/api/#tag/fine-tuning) for details.
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 
 ```python
@@ -378,7 +378,7 @@ curl -X POST https://api.mistral.ai/v1/fine_tuning/jobs/<jobid>/cancel \
 ## Use a fine-tuned model
 When a fine-tuned job is finished, you will be able to see the fine-tuned model name via `retrieved_jobs.fine_tuned_model`. Then you can use our `chat` endpoint to chat with the fine-tuned model: 
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 
 ```python
@@ -418,7 +418,7 @@ curl "https://api.mistral.ai/v1/chat/completions" \
 
 ## Delete a fine-tuned model
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 
 ```python

--- a/docs/capabilities/guardrailing.mdx
+++ b/docs/capabilities/guardrailing.mdx
@@ -16,7 +16,7 @@ We are releasing two end-points: one to classify raw text and one to classify co
 
 ### Raw-text endpoint
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 ```python
 import os
@@ -71,7 +71,7 @@ using the conversational endpoint and sending your conversation payload as shown
 below. Note that the model is trained to classify the last turn of a conversation
 given the conversational context.
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 ```python 
 import os
@@ -196,7 +196,7 @@ A: On our internal testset, policies have a precision between [0.8 - 0.9] and a 
 
 The ability to enforce guardrails in chat generations is crucial for front-facing applications. We introduce an optional system prompt to enforce guardrails on top of our models. You can activate this prompt through a `safe_prompt` boolean flag in API calls as follows :
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 ```python
 chat_response = client.chat.complete(

--- a/docs/deployment/cloud/outscale.mdx
+++ b/docs/deployment/cloud/outscale.mdx
@@ -41,7 +41,7 @@ To run the examples below you will need to set the following environment variabl
 - `OUTSCALE_MODEL_NAME`: the name of the model to query (e.g. `small-2409`, `codestral-2405`)
 
 
-<Tabs>
+<Tabs groupId="code">
     <TabItem value="curl" label="cURL">
         ```bash
         echo $OUTSCALE_SERVER_URL/v1/chat/completions
@@ -117,7 +117,7 @@ For more information, see the
 [code generation section](../../../capabilities/code_generation/#fill-in-the-middle-endpoint).
 
 
-<Tabs>
+<Tabs groupId="code">
     <TabItem value="curl" label="cURL">
        ```bash
         curl --location $OUTSCALE_SERVER_URL/v1/fim/completions \

--- a/docs/deployment/cloud/vertex.mdx
+++ b/docs/deployment/cloud/vertex.mdx
@@ -56,7 +56,7 @@ for more details.
     - `VERTEX_MODEL_VERSION`: The version of the model to query (e.g. `2407`).
     
 
-<Tabs>
+<Tabs groupId="code">
     <TabItem value="curl" label="cURL">
         ```bash
         base_url="https://$GOOGLE_CLOUD_REGION-aiplatform.googleapis.com/v1/projects/$GOOGLE_CLOUD_PROJECT_ID/locations/$GOOGLE_CLOUD_REGION/publishers/mistralai/models"
@@ -147,7 +147,7 @@ For more information, see the
 [code generation section](../../../capabilities/code_generation/#fill-in-the-middle-endpoint).
 
 
-<Tabs>
+<Tabs groupId="code">
     <TabItem value="curl" label="cURL">
         ```bash
         VERTEX_MODEL_NAME=codestral

--- a/docs/deployment/self-deployment/tgi.mdx
+++ b/docs/deployment/self-deployment/tgi.mdx
@@ -13,7 +13,7 @@ The easiest way of getting started with TGI is using the official Docker contain
 
 ## Deploying
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="mistral7b" label="Mistral-7B" default>
 
 ```bash
@@ -58,7 +58,7 @@ If the model does not fit in your GPU, you can also use quantization methods (AW
 
 TGI supports the [Messages API](https://huggingface.co/docs/text-generation-inference/en/messages_api) which is compatible with Mistral and OpenAI Chat Completion API.
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="mistralclient" label="Using MistralClient" default>
 
 ```python
@@ -121,7 +121,7 @@ curl http://127.0.0.1:8080/v1/chat/completions \
 
 If you want more control over what you send to the server, you can use the `generate` endpoint. In this case, you're responsible of formatting the prompt with the correct template and stop tokens.
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="Using Python" default>
 
 ```python

--- a/docs/deployment/self-deployment/vllm.mdx
+++ b/docs/deployment/self-deployment/vllm.mdx
@@ -44,7 +44,7 @@ querying Mistral models on vLLM.
 When using vLLM in _offline mode_ the model is loaded and used for one-off
 batch inference workloads.
 
-<Tabs>
+<Tabs groupId="code">
     <TabItem value="vllm-batch-nemo" label="Text input (Mistral NeMo)">
 
         ```python
@@ -155,7 +155,7 @@ waits for clients to connect and send requests concurrently.
 The server exposes a REST API that implements the OpenAI protocol,
 allowing you to directly reuse existing code relying on the OpenAI API.
 
-<Tabs>
+<Tabs groupId="code">
     <TabItem value="vllm-server-text" label="Text input (Mistral NeMo)">
         Start the inference server to deploy your model, e.g. for Mistral NeMo:
 
@@ -168,7 +168,7 @@ allowing you to directly reuse existing code relying on the OpenAI API.
 
         You can now run inference requests with text input:
 
-          <Tabs>
+          <Tabs groupId="code">
             <TabItem value="vllm-infer-nemo-curl" label="cURL">
                 ```bash
                 curl --location 'http://localhost:8000/v1/chat/completions' \
@@ -226,7 +226,7 @@ allowing you to directly reuse existing code relying on the OpenAI API.
 
         You can now run inference requests with text input:
 
-          <Tabs>
+          <Tabs groupId="code">
             <TabItem value="vllm-infer-small-curl" label="cURL">
                 ```bash
                 curl --location 'http://localhost:8000/v1/chat/completions' \
@@ -304,7 +304,7 @@ want to caption the following image:
         <br/>
 
 You can prompt the model and retrieve its response like so:
-    <Tabs>
+    <Tabs groupId="code">
         <TabItem value="vllm-infer-pixtral-curl" label="cURL">
         ```bash
         curl --location 'http://localhost:8000/v1/chat/completions' \
@@ -370,7 +370,7 @@ the project's official Docker image (see more details in the
   ```
 
 - Run the Docker command to start the container:
-  <Tabs>
+  <Tabs groupId="code">
     <TabItem value="vllm-docker-nemo" label="Mistral NeMo">
         ```bash
         docker run --runtime nvidia --gpus all \

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -33,7 +33,7 @@ Our API is currently available through [La Plateforme][platform_url].
 You need to activate payments on your account to enable your API keys.
 After a few moments, you will be able to use our `chat` endpoint:
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 ```python
 import os
@@ -94,7 +94,7 @@ endpoint and specify the embedding model `mistral-embed`, along with providing a
 The API will then return the corresponding embeddings as numerical vectors, which can be used for
 further analysis or processing in NLP applications.
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 ```python
 import os

--- a/docs/guides/finetuning_sections/_03_e2e_examples.md
+++ b/docs/guides/finetuning_sections/_03_e2e_examples.md
@@ -63,7 +63,7 @@ Let’s inspect one of these cases. There are two issues with this use case:
 ### Upload dataset
 We can then upload both the training data and evaluation data to the Mistral Client, making them available for use in fine-tuning jobs. 
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 
 ```python
@@ -145,7 +145,7 @@ Note that you will need the file IDs for the next steps.
 ### Create a fine-tuning job
 Next, we can create a fine-tuning job:
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 
 ```python
@@ -245,7 +245,7 @@ When we retrieve a model, we get the following metrics every 10% of the progress
 Both validation loss and validation token accuracy serve as essential indicators of the model's overall performance, helping to assess its ability to generalize and make accurate predictions on new data.
 
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 
 ```python
@@ -421,7 +421,7 @@ curl https://api.mistral.ai/v1/fine_tuning/jobs/<jobid> \
 When a fine-tuned job is finished, you will be able to see the fine-tuned model name via `retrieved_jobs.fine_tuned_model`. Then you can use our `chat` endpoint to chat with the fine-tuned model: 
 
 
-<Tabs>
+<Tabs groupId="code">
   <TabItem value="python" label="python" default>
 
 ```python


### PR DESCRIPTION
I am implementing here https://docusaurus.io/docs/markdown-features/tabs groupIDs, so that when you select in one of the tabs typescript it switched for all other tabs as well. This eases working with the docs. The next step for this topic would be to recall it and sync it across all pages.