### PR TITLE
docs: add Gleam client

### DIFF
--- a/docs/getting-started/clients.mdx
+++ b/docs/getting-started/clients.mdx
@@ -105,3 +105,6 @@ We recommend reaching out to the respective maintainers for any assistance or in
 
 ### Rust
 [ivangabriele/mistralai-client-rs](https://github.com/ivangabriele/mistralai-client-rs)
+
+### Gleam
+[Neofox/gleamstral](https://github.com/Neofox/gleamstral)


### PR DESCRIPTION
This PR as for purposes to add the gleam client https://github.com/Neofox/gleamstral to the clients page