### PR TITLE
OCR Doc: Wrong param name for ts

### DIFF
--- a/docs/capabilities/document.md
+++ b/docs/capabilities/document.md
@@ -56,7 +56,7 @@ const ocrResponse = await client.ocr.process({
         type: "document_url",
         documentUrl: "https://arxiv.org/pdf/2201.04234"
     },
-    include_image_base64: true
+    includeImageBase64: true
 });
 ```
   </TabItem>


### PR DESCRIPTION
`include_image_base64` was mentioned in typescript example for OCR but it should -> `includeImageBase64`