### PR TITLE
fix: signedUrl fix

### DIFF
--- a/docs/capabilities/document.md
+++ b/docs/capabilities/document.md
@@ -570,7 +570,7 @@ signed_url = client.files.get_signed_url(file_id=uploaded_pdf.id)
   <TabItem value="typescript" label="typescript">
 
 ```typescript
-const signedUrl = await mistral.files.getSignedUrl({
+const signedUrl = await client.files.getSignedUrl({
     fileId: uploaded_pdf.id,
 });
 ```


### PR DESCRIPTION
# Change
Fix issue with `mistral` instead of `client` in getting signedUrl example when using `TS` client.

After change:
![image](https://github.com/user-attachments/assets/5328fee8-51a7-4d73-93ed-c2de6f103b65)

Before change:
![image](https://github.com/user-attachments/assets/01f05607-0d7d-4c23-86bb-fc13a035b92e)
