### PR TITLE
Fix typos in models overview page

### DIFF
--- a/docs/getting-started/models/overview.md
+++ b/docs/getting-started/models/overview.md
@@ -19,7 +19,7 @@ Mistral provides two types of models: free models and premier models.
 | Codestral | | :heavy_check_mark: | Our cutting-edge language model for coding with the second version released January 2025, Codestral specializes in low-latency, high-frequency tasks such as fill-in-the-middle (FIM), code correction and test generation. Learn more on our [blog post](https://mistral.ai/news/codestral-2501/) | 256k  | `codestral-latest` | 25.01|
 | Mistral Large  |:heavy_check_mark: <br/> [Mistral Research License](https://mistral.ai/licenses/MRL-0.1.md)| :heavy_check_mark: |Our top-tier reasoning model for high-complexity tasks with the lastest version released November 2024. Learn more on our [blog post](https://mistral.ai/news/pixtral-large/) | 131k   | `mistral-large-latest`| 24.11|
 | Pixtral Large  |:heavy_check_mark: <br/> [Mistral Research License](https://mistral.ai/licenses/MRL-0.1.md)| :heavy_check_mark: |Our frontier-class multimodal model released November 2024. Learn more on our [blog post](https://mistral.ai/news/pixtral-large/)| 131k   | `pixtral-large-latest`| 24.11|
-| Mistral Saba  | | :heavy_check_mark: | A powerfull and efficient model for languages from the Middle East and South Asia. Learn more on our [blog post](https://mistral.ai/news/mistral-saba/)| 32k   | `mistral-saba-latest`| 25.02|
+| Mistral Saba  | | :heavy_check_mark: | A powerful and efficient model for languages from the Middle East and South Asia. Learn more on our [blog post](https://mistral.ai/news/mistral-saba/)| 32k   | `mistral-saba-latest`| 25.02|
 | Ministral 3B | | :heavy_check_mark: | World’s best edge model. Learn more on our [blog post](https://mistral.ai/news/ministraux/) | 131k  | `ministral-3b-latest` | 24.10|
 | Ministral 8B | :heavy_check_mark: <br/> [Mistral Research License](https://mistral.ai/licenses/MRL-0.1.md)| :heavy_check_mark: |Powerful edge model with extremely high performance/price ratio. Learn more on our [blog post](https://mistral.ai/news/ministraux/) | 131k  | `ministral-8b-latest` | 24.10|
 | Mistral Embed | | :heavy_check_mark: | Our state-of-the-art semantic for extracting representation of text extracts | 8k  | `mistral-embed` | 23.12|
@@ -32,7 +32,7 @@ Mistral provides two types of models: free models and premier models.
 
 | Model               | Weight availability|Available via API| Description | Max Tokens| API Endpoints|Version|
 |--------------------|:--------------------:|:--------------------:|:--------------------:|:--------------------:|:--------------------:|:--------------------:|
-| Mistral Small | :heavy_check_mark: <br/> Apache2 | :heavy_check_mark: | A new leader in the small models category with the lastest version v3 released January 2025. Learn more on our [blog post](https://mistral.ai/news/mistral-small-3/) | 32k  | `mistral-small-latest` | 25.01|
+| Mistral Small | :heavy_check_mark: <br/> Apache2 | :heavy_check_mark: | A new leader in the small models category with the latest version v3 released January 2025. Learn more on our [blog post](https://mistral.ai/news/mistral-small-3/) | 32k  | `mistral-small-latest` | 25.01|
 | Pixtral | :heavy_check_mark: <br/> Apache2 | :heavy_check_mark: | A 12B model with image understanding capabilities in addition to text. Learn more on our [blog post](https://mistral.ai/news/pixtral-12b/)| 131k  | `pixtral-12b-2409` | 24.09|
 
 - **Research models**


### PR DESCRIPTION
Fixes two typos in the model's overview page.