### PR TITLE
Adjust quickstart TypeScript example

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -71,7 +71,7 @@ const chatResponse = await client.chat.complete({
   messages: [{role: 'user', content: 'What is the best French cheese?'}],
 });
 
-console.log('Chat:', chatResponse.choices[0].message.content);
+console.log('Chat:', chatResponse.choices?.[0].message.content);
 ```
   </TabItem>
 


### PR DESCRIPTION
Added [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) to solve TypeScript error `'chatResponse.choices' is possibly 'undefined'.`