### PR TITLE
docs(ocr/basic/ocr): remove redundant import

### DIFF
--- a/docs/capabilities/OCR/basic_ocr.md
+++ b/docs/capabilities/OCR/basic_ocr.md
@@ -58,7 +58,6 @@ ocr_response = client.ocr.process(
 Or passing a Base64 encoded pdf:
 ```python
 import base64
-import requests
 import os
 from mistralai import Mistral
 
@@ -781,7 +780,6 @@ ocr_response = client.ocr.process(
 Or passing a Base64 encoded image:
 ```python
 import base64
-import requests
 import os
 from mistralai import Mistral
 


### PR DESCRIPTION
Removing redundant import of `requests` as it's not being used in the snippets.