### PR TITLE
fix(docs): correct typo in annotations.md

### DIFF
--- a/docs/capabilities/OCR/annotations.md
+++ b/docs/capabilities/OCR/annotations.md
@@ -225,7 +225,7 @@ curl --location 'https://api.mistral.ai/v1/ocr' \
 }'
 ```
 
-You can also add a `description` key in you `properties` object. The description will be used as detailed information and instructions during the annotation; for example:
+You can also add a `description` key in your `properties` object. The description will be used as detailed information and instructions during the annotation; for example:
 
 ```bash
 curl --location 'https://api.mistral.ai/v1/ocr' \


### PR DESCRIPTION
Just happened upon this typo when reading through the docs and wanted to propose a quick fix:

```markdown
You can also add a `description` key in you `properties` object.
```

The `you` should be `your`