### PR TITLE
Pins GH actions

### DIFF
--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           token: ${{ secrets.PUBLIC_DOCS_WRITE_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/delete-branch-after-merge.yaml
+++ b/.github/workflows/delete-branch-after-merge.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           token: ${{ secrets.PUBLIC_DOCS_WRITE_TOKEN }}
           submodules: true

--- a/.github/workflows/generate_llms_txt.yml
+++ b/.github/workflows/generate_llms_txt.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.10'
 
@@ -33,7 +33,7 @@ jobs:
 
       # PR for all changes produced above
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           token: ${{ secrets.PUBLIC_DOCS_WRITE_TOKEN }}
           branch: auto/docs-update

--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           token: ${{ secrets.PUBLIC_DOCS_WRITE_TOKEN }}
           submodules: true


### PR DESCRIPTION
We're in the process of reinforcing our GitHub Actions by requiring them to use pinned releases, in line with [security good practices](https://docs.github.com/en/actions/reference/security/secure-use). Before enforcing that we first need to update the current `uses` references to use the proper syntax.

_(PR generated semi-automatically)_