### PR TITLE
Fix contribution guidelines link

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,4 @@ This documentation is built using [Docusaurus](https://docusaurus.io/).
 
 # How to contribute?
 
-Mistral AI is committed to open source software development and welcomes external contributions. Please head on to our [contribution guideline](https://docs.mistral.ai/guides/contribute/). 
+Mistral AI is committed to open source software development and welcomes external contributions. Please head on to our [contribution guideline](https://platform-docs-public.pages.dev/guides/contribute/overview/). 


### PR DESCRIPTION

The contribution guidelines link referenced in the README is broken the page does not exist (I have checked the codebase).

This MR fixes the issue by updating the link to point to Mistral’s official contribution guidelines:

https://platform-docs-public.pages.dev/guides/contribute/overview/

If there is a template or a detailed contribution guidelines document available, I would be happy to integrate it into the Mistral documentation.

Ref #337 