### PR TITLE
fix(docs) - huggingface-cli is deprecated, use hf

### DIFF
--- a/src/app/(docs)/models/deployment/local-deployment/vllm/page.mdx
+++ b/src/app/(docs)/models/deployment/local-deployment/vllm/page.mdx
@@ -32,7 +32,7 @@ The following sections will guide you through the process of deploying and query
 - Create a Python virtual environment and install the `vllm` package (version `>=0.6.1.post1` to ensure maximum compatibility with all Mistral models).
 - Authenticate on the HuggingFace Hub using your access token `$HF_TOKEN`:
   ```bash
-  huggingface-cli login --token $HF_TOKEN
+  hf login --token $HF_TOKEN
   ```
 
 <SectionTab as="h2" variant="secondary" sectionId="offline-mode-inference">Offline Mode Inference</SectionTab>

--- a/src/app/(docs)/models/deployment/local-deployment/vllm/page.mdx
+++ b/src/app/(docs)/models/deployment/local-deployment/vllm/page.mdx
@@ -32,7 +32,7 @@ The following sections will guide you through the process of deploying and query
 - Create a Python virtual environment and install the `vllm` package (version `>=0.6.1.post1` to ensure maximum compatibility with all Mistral models).
 - Authenticate on the HuggingFace Hub using your access token `$HF_TOKEN`:
   ```bash
-  hf login --token $HF_TOKEN
+  hf auth login --token $HF_TOKEN
   ```
 
 <SectionTab as="h2" variant="secondary" sectionId="offline-mode-inference">Offline Mode Inference</SectionTab>


### PR DESCRIPTION
Warning: `huggingface-cli` is deprecated and no longer works. Use `hf` instead.