### PR TITLE
[VIBE-2581] Adjust Shift+Tab /help description in quickstart

### DIFF
--- a/src/app/(docs)/(products)/mistral-vibe/terminal/quickstart/page.mdx
+++ b/src/app/(docs)/(products)/mistral-vibe/terminal/quickstart/page.mdx
@@ -82,7 +82,7 @@ Run `vibe` to enter the interactive chat loop. This mode provides a chat interfa
 - **External Editor**: Press `Ctrl+G` to edit your current input in an external editor.
 - **Tool Output Toggle**: Press `Ctrl+O` to toggle the tool output view.
 - **Todo View Toggle**: Press `Ctrl+T` to toggle the todo list view.
-- **Auto-Approve Toggle**: Press `Shift+Tab` to toggle auto-approve mode on/off.
+- **Cycle agents**: Press `Shift+Tab` to cycle through agents (default, plan, …).
 
 You can also directly start Vibe with a prompt with the following command:
 
@@ -96,7 +96,7 @@ Mistral Vibe also allows you to use slash commands and keyboard shortcuts for me
 - `/clear`: Clear conversation history
 - `/teleport`: Move the current local session to a cloud sandbox. See the [Vibe Code Workflow](/le-chat/content-creation/vibe-code-workflow) for setup and limits.
 - `Ctrl+T` Toggle todo view
-- `Shift+Tab` Toggle auto-approve mode
+- `Shift+Tab` Cycle through agents (default, plan, …)
 - And more... Use `/help` to display all available commands.
 
 <SectionTab as="h3" variant="secondary" sectionId="custom-slash-commands">Custom Slash Commands</SectionTab>


### PR DESCRIPTION
Adjust the Vibe CLI quickstart doc to explicit that `shift+tab` allow to cycle through agent (default, plan, ...), not just toggling auto approve.