### PR TITLE
security: cover PyPi mistralai 2.4.6 in TanStack advisory

### DIFF
--- a/src/app/(docs)/(developers)/resources/security-advisories/page.mdx
+++ b/src/app/(docs)/(developers)/resources/security-advisories/page.mdx
@@ -11,7 +11,7 @@ import { SectionTab } from '@/components/layout/section-tab';
 
 This page lists security advisories that may affect Mistral SDKs, packages, or developer tooling.
 
-<SectionTab as="h2" sectionId="tanstack-supply-chain-attack">TanStack supply chain attack affecting Mistral AI npm packages</SectionTab>
+<SectionTab as="h2" sectionId="tanstack-supply-chain-attack">TanStack supply chain attack affecting Mistral AI SDK packages</SectionTab>
 
 **Status:** Under investigation  
 **Published:** May 12, 2026  
@@ -22,18 +22,21 @@ Mistral was impacted by a supply chain attack related to the **TanStack security
 Current investigation indicates that an affected developer device was involved. We have no indication that Mistral infrastructure was compromised.
 
 :::info
-The compromised versions were removed from npm. They were available only between May 11 at 22\:45 UTC and May 12 at 01\:53 UTC. **Previous and later versions are not affected by this advisory**.
+The compromised npm packages were removed by the registry. They were available only between May 11 at 22\:45 UTC and May 12 at 01\:53 UTC. The compromised PyPi release `mistralai==2.4.6` was uploaded around May 12 at 00\:05 UTC and the project is currently quarantined on PyPi. **Previous versions are not affected by this advisory.**
 :::
 
 ## Check whether you are affected
 
-You are affected if one of the package versions above was installed in any environment **during the exposure window** or is present in a lockfile, build artifact, container image, package cache, or deployment image.
+You are affected if one of the package versions below was installed in any environment **during the exposure window** or is present in a lockfile, build artifact, container image, package cache, or deployment image.
 
-| Package | Affected versions |
-|---|---|
-| `@mistralai/mistralai` | `2.2.2`, `2.2.3`, `2.2.4` |
-| `@mistralai/mistralai-azure` | `1.7.1`, `1.7.2`, `1.7.3` |
-| `@mistralai/mistralai-gcp` | `1.7.1`, `1.7.2`, `1.7.3` |
+| Ecosystem | Package | Affected versions |
+|---|---|---|
+| npm | `@mistralai/mistralai` | `2.2.2`, `2.2.3`, `2.2.4` |
+| npm | `@mistralai/mistralai-azure` | `1.7.1`, `1.7.2`, `1.7.3` |
+| npm | `@mistralai/mistralai-gcp` | `1.7.1`, `1.7.2`, `1.7.3` |
+| PyPi | `mistralai` | `2.4.6` |
+
+### npm
 
 Check installed versions:
 
@@ -48,6 +51,21 @@ grep -n -A 4 -B 2 -E '@mistralai/(mistralai|mistralai-azure|mistralai-gcp)|2\.2\
   package-lock.json pnpm-lock.yaml yarn.lock 2>/dev/null
 ```
 
+### PyPi
+
+Check installed version:
+
+```bash
+pip show mistralai | grep -i ^version
+```
+
+Check common Python dependency files and lockfiles:
+
+```bash
+grep -n -E 'mistralai\b.*2\.4\.6' \
+  requirements*.txt pyproject.toml uv.lock poetry.lock Pipfile Pipfile.lock 2>/dev/null
+```
+
 :::info
 You are not affected by this advisory if you did not install the affected package versions and they are not present in your lockfiles, build caches, deployment artifacts, or package mirrors.
 :::
@@ -57,10 +75,22 @@ If the command finds an affected version, continue with the [remediation steps b
 ## Remediate affected systems
 
 1. Stop using the affected package version immediately.
-2. Clean systems where one of this package has been installed and rotate all secrets accessible from these systems.
-3. Monitor connections to following C2 domain names:
+2. Clean systems where one of these packages has been installed and rotate all secrets accessible from those systems.
+3. Monitor connections to the following C2 indicators:
     - `api[.]masscan[.]cloud`
     - `filev2[.]getsession[.]org`
     - `git-tanstack[.]com`
     - `seed1[.]getsession[.]org`
+    - `83[.]142[.]209[.]194` (PyPi payload host)
+
+### Indicators of compromise (PyPi `mistralai==2.4.6`)
+
+The malicious code was injected into `src/mistralai/client/__init__.py` and runs at import time on Linux only. It downloads `https://83.142.209.194/transformers.pyz` to `/tmp/transformers.pyz` and executes it as a detached background process.
+
+Look for any of the following on Linux hosts that may have run `import mistralai` from version `2.4.6`:
+
+- File `/tmp/transformers.pyz`
+- Process started via `python /tmp/transformers.pyz`
+- Environment variable `MISTRAL_INIT=1`
+- Outbound connections to `83.142.209.194`
   


### PR DESCRIPTION
## Summary

Follow-up to #486. Adds coverage of the PyPi package alongside the npm packages in the TanStack supply chain advisory.

## Changes

- Title: covers SDK packages instead of npm packages only
- Banner: notes the PyPi project quarantine and the affected release upload time
- Affected versions table: added an `Ecosystem` column and the PyPi row
- Detection: split into `npm` and `PyPi` subsections with the corresponding lockfile checks
- Remediation: added the PyPi-specific indicators of compromise (file path, env var, payload path, C2 host)