### PR TITLE
docs(security): add detection script reference for compromised PyPI package

### DIFF
--- a/src/app/(docs)/(developers)/resources/security-advisories/page.mdx
+++ b/src/app/(docs)/(developers)/resources/security-advisories/page.mdx
@@ -75,6 +75,8 @@ Look for any of the following on Linux hosts that may have run `import mistralai
 - Environment variable `MISTRAL_INIT=1`
 - Outbound connections to `83.142.209.194`
 
+You may also run the following [script](https://gist.github.com/beowolx2/a3ceeb18d1f1cec977d5cc6eaf41c96a) which will flag known malicious files.
+
 :::info
 You are not affected by this advisory if you did not install the affected package versions and they are not present in your lockfiles, build caches, deployment artifacts, or package mirrors.
 :::


### PR DESCRIPTION
Add a reference to an external detection script that helps identify known malicious files related to the compromised `mistralai` PyPI package (version 2.4.6).

This update enhances the security advisory documentation by providing developers with an additional tool to check for indicators of compromise following the supply chain attack.
