### PR TITLE
feat: add Configuration section to Slack integration page

### DIFF
--- a/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
+++ b/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
@@ -18,7 +18,7 @@ Use this guide after the Vibe Code Web Slack app has been installed and connecte
 You need to be an admin of your Mistral Organization to configure the Slack integration.
 :::
 
-1. Go to **Admin Settings**
+1. Go to [**Admin Settings**](https://admin.mistral.ai/organization/connectors)
 
    <div><CtaButton href="https://admin.mistral.ai/organization/connectors">Open Admin settings</CtaButton></div>
 2. Make sure you are in the right Mistral organization. Your Mistral organization can only be connected to a single Slack Workspace.

--- a/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
+++ b/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
@@ -6,6 +6,8 @@ sidebar_position: 1
 import { SectionTab } from '@/components/layout/section-tab';
 import { CtaButton } from '@/components/common/cta-button';
 
+export const adminConnectorsUrl = 'https://admin.mistral.ai/organization/connectors';
+
 # Vibe Code Web for Slack: Quickstart
 
 Use this guide after the Vibe Code Web Slack app has been installed and connected to your Vibe account and GitHub repositories.
@@ -16,11 +18,13 @@ Use this guide after the Vibe Code Web Slack app has been installed and connecte
 
 :::warning
 You need to be an admin of your Mistral Organization to configure the Slack integration.
+
+<CtaButton href="{adminConnectorsUrl}">
+  Open Admin settings
+</CtaButton>
 :::
 
-1. Go to [**Admin Settings**](https://admin.mistral.ai/organization/connectors)
-
-   <div><CtaButton href="https://admin.mistral.ai/organization/connectors">Open Admin settings</CtaButton></div>
+1. Go to [**Admin Settings**]({adminConnectorsUrl})
 2. Make sure you are in the right Mistral organization. Your Mistral organization can only be connected to a single Slack Workspace.
 3. In the **App Connections** section, click **Connect to Slack**.
 4. Complete the OAuth flow to finalise the connection. If you are not an owner of your Slack workspace, you may need to request app installation from a workspace owner.

--- a/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
+++ b/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
@@ -6,7 +6,8 @@ sidebar_position: 1
 import { SectionTab } from '@/components/layout/section-tab';
 import { CtaButton } from '@/components/common/cta-button';
 
-export const adminConnectorsUrl = 'https://admin.mistral.ai/organization/connectors';
+export const adminConnectorsUrl =
+  'https://admin.mistral.ai/organization/connectors';
 
 # Vibe Code Web for Slack: Quickstart
 
@@ -19,14 +20,14 @@ Use this guide after the Vibe Code Web Slack app has been installed and connecte
 :::warning
 You need to be an admin of your Mistral Organization to configure the Slack integration.
 
-<CtaButton href={adminConnectorsUrl}>
+<CtaButton href="https://admin.mistral.ai/organization/connectors">
   Open Admin settings
 </CtaButton>
 :::
 
-1. Go to <a href={adminConnectorsUrl} target="_blank" rel="noopener noreferrer"><strong>Admin Settings</strong></a>
-2. Make sure you are in the right Mistral organization. Your Mistral organization can only be connected to a single Slack Workspace.
-3. In the **App Connections** section, click **Connect to Slack**.
+1. Open [**Admin Settings**](https://admin.mistral.ai/organization/connectors)
+2. **Make sure you are in the right Mistral organization.** Your Mistral organization can only be connected to a single Slack Workspace.
+3. In **App Connections** section, click **Connect to Slack**.
 4. Complete the OAuth flow to finalise the connection. If you are not an owner of your Slack workspace, you may need to request app installation from a workspace owner.
 5. **Mistral Vibe** is now installed in your Slack workspace.
 

--- a/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
+++ b/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
@@ -4,10 +4,24 @@ sidebar_position: 1
 ---
 
 import { SectionTab } from '@/components/layout/section-tab';
+import { LinkCard } from '@/components/common/link-card';
+import { CtaButton } from '@/components/common/cta-button';
 
 # Vibe Code Web for Slack: Quickstart
 
 Use this guide after the Vibe Code Web Slack app has been installed and connected to your Vibe account and GitHub repositories.
+
+<SectionTab as="h1" sectionId="configuration">Configuration</SectionTab>
+
+:::warning
+You need to be an admin of your Mistral Organization to configure the Slack integration.
+:::
+
+<LinkCard href="https://admin.mistral.ai/organization/connectors" title="Go to Admin settings — App Connections" />
+
+1. In the **App Connections** section, click **Connect to Slack**.
+2. Complete the OAuth flow to finalise the connection. If you are not an owner of your Slack workspace, you may need to request app installation from a workspace owner.
+3. **Mistral Vibe** is now installed in your Slack workspace.
 
 <SectionTab as="h1" sectionId="what-you-can-do">What you can do from Slack</SectionTab>
 

--- a/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
+++ b/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Vibe Code Web for Slack: Quickstart"
+title: 'Vibe Code Web for Slack: Quickstart'
 sidebar_position: 1
 ---
 
@@ -10,19 +10,25 @@ import { CtaButton } from '@/components/common/cta-button';
 
 Use this guide after the Vibe Code Web Slack app has been installed and connected to your Vibe account and GitHub repositories.
 
-<SectionTab as="h1" sectionId="configuration">Configuration</SectionTab>
+<SectionTab as="h1" sectionId="configuration">
+  Configuration
+</SectionTab>
 
 :::warning
 You need to be an admin of your Mistral Organization to configure the Slack integration.
 :::
 
-<CtaButton href="https://admin.mistral.ai/organization/connectors">Open Admin settings</CtaButton>
+1. Go to **Admin Settings**
 
-1. In the **App Connections** section, click **Connect to Slack**.
-2. Complete the OAuth flow to finalise the connection. If you are not an owner of your Slack workspace, you may need to request app installation from a workspace owner.
-3. **Mistral Vibe** is now installed in your Slack workspace.
+   <CtaButton href="https://admin.mistral.ai/organization/connectors">Open Admin settings</CtaButton>
+2. Make sure you are in the right Mistral organization. Your Mistral organization can only be connected to a single Slack Workspace.
+3. In the **App Connections** section, click **Connect to Slack**.
+4. Complete the OAuth flow to finalise the connection. If you are not an owner of your Slack workspace, you may need to request app installation from a workspace owner.
+5. **Mistral Vibe** is now installed in your Slack workspace.
 
-<SectionTab as="h1" sectionId="what-you-can-do">What you can do from Slack</SectionTab>
+<SectionTab as="h1" sectionId="what-you-can-do">
+  What you can do from Slack
+</SectionTab>
 
 Vibe Code Web lets you start a remote coding session from the context already in a Slack thread. The agent uses the thread context, works in an isolated cloud sandbox, and creates a linked Vibe Code Web session. The coding agent can create a pull request for review.
 
@@ -35,40 +41,46 @@ Use Slack when the coding task starts from:
 - a code review discussion summarized in Slack
 - a small implementation decision already agreed in-thread
 
-<SectionTab as="h1" sectionId="start-first-session">Start your first session</SectionTab>
+<SectionTab as="h1" sectionId="start-first-session">
+  Start your first session
+</SectionTab>
 
 1. **Find a Slack thread with enough context for the coding task.** Good context includes:
-    - the repository or project name
-    - the bug, failing test, or desired behavior
-    - links to logs, PRs, issues, or screenshots
-    - constraints, such as *"keep the API unchanged"* or *"only touch docs"*
+   - the repository or project name
+   - the bug, failing test, or desired behavior
+   - links to logs, PRs, issues, or screenshots
+   - constraints, such as _"keep the API unchanged"_ or _"only touch docs"_
 2. **Mention the Vibe Code app in the thread.**
-    ```text
-    @MistralVibe investigate the issue described in this thread and open a PR if there is a clear fix.
-    ```
+   ```text
+   @MistralVibe investigate the issue described in this thread and open a PR if there is a clear fix.
+   ```
 3. **If Vibe needs more information, answer in the thread.** Common clarification questions:
-    - Which repository should I use?
-    - Which branch should I target?
-    - Should I open a PR or only investigate?
-    - Is this safe to change, or should I produce a summary first?
+   - Which repository should I use?
+   - Which branch should I target?
+   - Should I open a PR or only investigate?
+   - Is this safe to change, or should I produce a summary first?
 4. **Open the Vibe Code Web session link posted by the app.** Use the web session to inspect progress, command output, steer the agent, and review the resulting GitHub branch or pull request.
 5. **Review the final code in GitHub.** GitHub remains the source of truth for code review, required checks, comments, approvals, and merge decisions.
 
-<SectionTab as="h1" sectionId="good-first-prompts">Good first prompts</SectionTab>
+<SectionTab as="h1" sectionId="good-first-prompts">
+  Good first prompts
+</SectionTab>
 
 Use prompts that are scoped, actionable, and likely to end in a branch or pull request.
 
-| Use case | Slack prompt |
-| --- | --- |
-| **Investigate a failing test** | `@MistralVibe investigate the failing test in this thread. If the fix is clear, open a PR with the smallest safe change.` |
-| **Fix a customer-reported bug** | `@MistralVibe use the customer report above to find the likely bug. Open a PR if you can reproduce or identify a clear fix.` |
-| **Address an alert** | `@MistralVibe investigate this alert and check whether there is a code or config fix. Start with a summary, then open a PR only if the change is low risk.` |
-| **Apply an agreed product change** | `@MistralVibe implement the copy/config change we agreed on above and open a PR.` |
-| **Add missing test coverage** | `@MistralVibe add a regression test for the edge case described in this thread. Keep the implementation unchanged unless the test exposes a bug.` |
-| **Update docs** | `@MistralVibe update the docs based on the behavior described above. Open a PR with the doc-only change.` |
-| **Small refactor** | `@MistralVibe refactor the helper discussed above. Keep behavior unchanged and run the relevant tests before opening a PR.` |
+| Use case                           | Slack prompt                                                                                                                                                |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Investigate a failing test**     | `@MistralVibe investigate the failing test in this thread. If the fix is clear, open a PR with the smallest safe change.`                                   |
+| **Fix a customer-reported bug**    | `@MistralVibe use the customer report above to find the likely bug. Open a PR if you can reproduce or identify a clear fix.`                                |
+| **Address an alert**               | `@MistralVibe investigate this alert and check whether there is a code or config fix. Start with a summary, then open a PR only if the change is low risk.` |
+| **Apply an agreed product change** | `@MistralVibe implement the copy/config change we agreed on above and open a PR.`                                                                           |
+| **Add missing test coverage**      | `@MistralVibe add a regression test for the edge case described in this thread. Keep the implementation unchanged unless the test exposes a bug.`           |
+| **Update docs**                    | `@MistralVibe update the docs based on the behavior described above. Open a PR with the doc-only change.`                                                   |
+| **Small refactor**                 | `@MistralVibe refactor the helper discussed above. Keep behavior unchanged and run the relevant tests before opening a PR.`                                 |
 
-<SectionTab as="h1" sectionId="prompt-template">Prompt template</SectionTab>
+<SectionTab as="h1" sectionId="prompt-template">
+  Prompt template
+</SectionTab>
 
 For best results, include the repo, the desired outcome, and the review boundary.
 
@@ -94,7 +106,9 @@ Validation: run the settings tests if available.
 Output: open a PR if the fix is clear; otherwise summarize what you found.
 ```
 
-<SectionTab as="h1" sectionId="what-happens-next">What happens next</SectionTab>
+<SectionTab as="h1" sectionId="what-happens-next">
+  What happens next
+</SectionTab>
 
 After you mention Vibe Code:
 
@@ -105,15 +119,19 @@ After you mention Vibe Code:
 5. The agent works remotely in a managed sandbox.
 6. The result is a GitHub branch or pull request, when a code change is appropriate.
 
-<SectionTab as="h1" sectionId="slack-vs-web-vs-cli">When to use Slack vs Web vs CLI</SectionTab>
+<SectionTab as="h1" sectionId="slack-vs-web-vs-cli">
+  When to use Slack vs Web vs CLI
+</SectionTab>
 
-| Start from | Use when |
-| --- | --- |
-| **Slack** | The context already lives in a Slack thread: incidents, support reports, alerts, or team decisions. |
-| **Vibe Code Web** | You know the repository and want to start a remote task directly. |
-| **Vibe CLI** | You are already working locally, or the task depends on local files, services, secrets, or environment setup. |
+| Start from        | Use when                                                                                                      |
+| ----------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Slack**         | The context already lives in a Slack thread: incidents, support reports, alerts, or team decisions.           |
+| **Vibe Code Web** | You know the repository and want to start a remote task directly.                                             |
+| **Vibe CLI**      | You are already working locally, or the task depends on local files, services, secrets, or environment setup. |
 
-<SectionTab as="h1" sectionId="best-practices">Best practices</SectionTab>
+<SectionTab as="h1" sectionId="best-practices">
+  Best practices
+</SectionTab>
 
 - Start with small, scoped tasks.
 - Name the repository or project when possible.
@@ -123,7 +141,9 @@ After you mention Vibe Code:
 - Do not paste secrets into Slack or into the agent prompt.
 - Review the resulting branch or pull request in GitHub before merging.
 
-<SectionTab as="h1" sectionId="good-tasks">Good Slack tasks</SectionTab>
+<SectionTab as="h1" sectionId="good-tasks">
+  Good Slack tasks
+</SectionTab>
 
 Good Slack-started tasks usually:
 
@@ -133,12 +153,14 @@ Good Slack-started tasks usually:
 - can be validated with tests, build output, or code inspection
 - end in a GitHub branch, pull request, or investigation summary
 
-<SectionTab as="h1" sectionId="less-ideal-tasks">Less ideal Slack tasks</SectionTab>
+<SectionTab as="h1" sectionId="less-ideal-tasks">
+  Less ideal Slack tasks
+</SectionTab>
 
 Avoid Slack-triggered sessions for:
 
 - broad architecture changes without a clear owner
 - tasks requiring local-only services, secrets, hardware, or private networks
-- vague prompts like *"fix this"* without logs or expected behavior
+- vague prompts like _"fix this"_ without logs or expected behavior
 - cross-owner GitHub work unless the project and repo mapping is clear
 - changes that should be manually designed before implementation

--- a/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
+++ b/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
@@ -20,7 +20,7 @@ You need to be an admin of your Mistral Organization to configure the Slack inte
 
 1. Go to **Admin Settings**
 
-   <CtaButton href="https://admin.mistral.ai/organization/connectors">Open Admin settings</CtaButton>
+   <div><CtaButton href="https://admin.mistral.ai/organization/connectors">Open Admin settings</CtaButton></div>
 2. Make sure you are in the right Mistral organization. Your Mistral organization can only be connected to a single Slack Workspace.
 3. In the **App Connections** section, click **Connect to Slack**.
 4. Complete the OAuth flow to finalise the connection. If you are not an owner of your Slack workspace, you may need to request app installation from a workspace owner.

--- a/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
+++ b/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
@@ -4,7 +4,6 @@ sidebar_position: 1
 ---
 
 import { SectionTab } from '@/components/layout/section-tab';
-import { LinkCard } from '@/components/common/link-card';
 import { CtaButton } from '@/components/common/cta-button';
 
 # Vibe Code Web for Slack: Quickstart
@@ -17,7 +16,7 @@ Use this guide after the Vibe Code Web Slack app has been installed and connecte
 You need to be an admin of your Mistral Organization to configure the Slack integration.
 :::
 
-<LinkCard href="https://admin.mistral.ai/organization/connectors" title="Go to Admin settings — App Connections" />
+<CtaButton href="https://admin.mistral.ai/organization/connectors">Open Admin settings</CtaButton>
 
 1. In the **App Connections** section, click **Connect to Slack**.
 2. Complete the OAuth flow to finalise the connection. If you are not an owner of your Slack workspace, you may need to request app installation from a workspace owner.

--- a/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
+++ b/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
@@ -19,12 +19,12 @@ Use this guide after the Vibe Code Web Slack app has been installed and connecte
 :::warning
 You need to be an admin of your Mistral Organization to configure the Slack integration.
 
-<CtaButton href="{adminConnectorsUrl}">
+<CtaButton href={adminConnectorsUrl}>
   Open Admin settings
 </CtaButton>
 :::
 
-1. Go to [**Admin Settings**]({adminConnectorsUrl})
+1. Go to <a href={adminConnectorsUrl} target="_blank" rel="noopener noreferrer"><strong>Admin Settings</strong></a>
 2. Make sure you are in the right Mistral organization. Your Mistral organization can only be connected to a single Slack Workspace.
 3. In the **App Connections** section, click **Connect to Slack**.
 4. Complete the OAuth flow to finalise the connection. If you are not an owner of your Slack workspace, you may need to request app installation from a workspace owner.


### PR DESCRIPTION
## Summary

- Adds a **Configuration** section at the top of the Vibe Code Web for Slack quickstart page
- Includes a `:::warning` admonition noting that admin rights are required
- Uses a `LinkCard` (prominent card with pixelized background animation) linking directly to `https://admin.mistral.ai/organization/connectors` so the CTA is unmissable
- Lists the 3-step OAuth setup flow

## Test plan

- [ ] Verify the warning admonition renders correctly
- [ ] Verify the `LinkCard` renders with the pixelized background and links to the correct URL
- [ ] Verify the numbered steps display correctly
- [ ] Check that the section appears in the sidebar under "Configuration"