### PR TITLE
fix(vibe): use @Vibe instead of @MistralVibe in Slack docs

### DIFF
--- a/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
+++ b/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
@@ -57,7 +57,7 @@ Use Slack when the coding task starts from:
    - constraints, such as _"keep the API unchanged"_ or _"only touch docs"_
 2. **Mention the Vibe Code app in the thread.**
    ```text
-   @MistralVibe investigate the issue described in this thread and open a PR if there is a clear fix.
+   @Vibe investigate the issue described in this thread and open a PR if there is a clear fix.
    ```
 3. **If Vibe needs more information, answer in the thread.** Common clarification questions:
    - Which repository should I use?
@@ -75,13 +75,13 @@ Use prompts that are scoped, actionable, and likely to end in a branch or pull r
 
 | Use case                           | Slack prompt                                                                                                                                                |
 | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Investigate a failing test**     | `@MistralVibe investigate the failing test in this thread. If the fix is clear, open a PR with the smallest safe change.`                                   |
-| **Fix a customer-reported bug**    | `@MistralVibe use the customer report above to find the likely bug. Open a PR if you can reproduce or identify a clear fix.`                                |
-| **Address an alert**               | `@MistralVibe investigate this alert and check whether there is a code or config fix. Start with a summary, then open a PR only if the change is low risk.` |
-| **Apply an agreed product change** | `@MistralVibe implement the copy/config change we agreed on above and open a PR.`                                                                           |
-| **Add missing test coverage**      | `@MistralVibe add a regression test for the edge case described in this thread. Keep the implementation unchanged unless the test exposes a bug.`           |
-| **Update docs**                    | `@MistralVibe update the docs based on the behavior described above. Open a PR with the doc-only change.`                                                   |
-| **Small refactor**                 | `@MistralVibe refactor the helper discussed above. Keep behavior unchanged and run the relevant tests before opening a PR.`                                 |
+| **Investigate a failing test**     | `@Vibe investigate the failing test in this thread. If the fix is clear, open a PR with the smallest safe change.`                                   |
+| **Fix a customer-reported bug**    | `@Vibe use the customer report above to find the likely bug. Open a PR if you can reproduce or identify a clear fix.`                                |
+| **Address an alert**               | `@Vibe investigate this alert and check whether there is a code or config fix. Start with a summary, then open a PR only if the change is low risk.` |
+| **Apply an agreed product change** | `@Vibe implement the copy/config change we agreed on above and open a PR.`                                                                           |
+| **Add missing test coverage**      | `@Vibe add a regression test for the edge case described in this thread. Keep the implementation unchanged unless the test exposes a bug.`           |
+| **Update docs**                    | `@Vibe update the docs based on the behavior described above. Open a PR with the doc-only change.`                                                   |
+| **Small refactor**                 | `@Vibe refactor the helper discussed above. Keep behavior unchanged and run the relevant tests before opening a PR.`                                 |
 
 <SectionTab as="h1" sectionId="prompt-template">
   Prompt template
@@ -90,7 +90,7 @@ Use prompts that are scoped, actionable, and likely to end in a branch or pull r
 For best results, include the repo, the desired outcome, and the review boundary.
 
 ```text
-@MistralVibe [task]
+@Vibe [task]
 
 Repo/project: [repo name]
 Goal: [what should change]
@@ -102,7 +102,7 @@ Output: open a PR / investigate only / summarize first
 Example:
 
 ```text
-@MistralVibe fix the settings persistence bug described above.
+@Vibe fix the settings persistence bug described above.
 
 Repo/project: web-app
 Goal: the alerts toggle should still be enabled after refresh.


### PR DESCRIPTION
Per Joris/Maxime in Slack: the bot handle is `@Vibe`, not `@MistralVibe`.

Updates 10 occurrences in `src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx`.