### PR TITLE
docs: add Slack MCP section and progressive rollout warning

### DIFF
--- a/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
+++ b/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
@@ -6,9 +6,6 @@ sidebar_position: 1
 import { SectionTab } from '@/components/layout/section-tab';
 import { CtaButton } from '@/components/common/cta-button';
 
-export const adminConnectorsUrl =
-  'https://admin.mistral.ai/organization/connectors';
-
 # Vibe Code Web for Slack: Quickstart
 
 Use this guide after the Vibe Code Web Slack app has been installed and connected to your Vibe account and GitHub repositories.
@@ -31,9 +28,25 @@ You need to be an admin of your Mistral Organization to configure the Slack inte
 4. Complete the OAuth flow to finalise the connection. If you are not an owner of your Slack workspace, you may need to request app installation from a workspace owner.
 5. **Mistral Vibe** is now installed in your Slack workspace.
 
+<SectionTab as="h1" sectionId="configuration">
+  Using Slack MCP
+</SectionTab>
+
+You are all setup to use Slack MCP. From there, please follow these instructions:
+
+1. Open [**Vibe Work**](https://chat.mistral.ai/connections)
+2. Click on **Slack Connector**, then click **Connect**
+3. Complete OAuth flow to connect to the right Slack workspace you have
+4. Click on [**New Chat**](https://chat.mistral.ai/chat?integrations=019cfb41-5e8a-7350-b162-b2b80604fe5a)
+5. Enjoy playing with Slack!
+
 <SectionTab as="h1" sectionId="what-you-can-do">
   What you can do from Slack
 </SectionTab>
+
+:::warning
+This feature is in progressive rollout. It will be available soon, stay tuned...
+:::
 
 Vibe Code Web lets you start a remote coding session from the context already in a Slack thread. The agent uses the thread context, works in an isolated cloud sandbox, and creates a linked Vibe Code Web session. The coding agent can create a pull request for review.
 


### PR DESCRIPTION
## Changes

- Add a new **'Using Slack MCP'** section to the Slack integration quickstart page with step-by-step setup instructions (Vibe Work connection, OAuth flow, new chat link)
- Add a **progressive rollout warning** to the 'What you can do from Slack' section
- Remove the `adminConnectorsUrl` variable extraction (reverted from previous PR)