### PR TITLE
docs: add AI-generated content disclaimer section

### DIFF
--- a/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
+++ b/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
@@ -182,3 +182,11 @@ Avoid Slack-triggered sessions for:
 - vague prompts like _"fix this"_ without logs or expected behavior
 - cross-owner GitHub work unless the project and repo mapping is clear
 - changes that should be manually designed before implementation
+
+<SectionTab as="h1" sectionId="ai-disclaimer">
+  AI-generated content disclaimer
+</SectionTab>
+
+:::warning
+This app includes AI-generated content and responses. AI outputs may be inaccurate, incomplete, or misleading and should not be relied upon as factual, legal, medical, financial, or professional advice. Please verify important information independently.
+:::


### PR DESCRIPTION
## Changes

Adds a final **AI-generated content disclaimer** section at the bottom of the Slack integration quickstart page, rendered as a warning callout.

> This app includes AI-generated content and responses. AI outputs may be inaccurate, incomplete, or misleading and should not be relied upon as factual, legal, medical, financial, or professional advice. Please verify important information independently.