### PR TITLE
docs: address Slack Marketplace landing page compliance gaps

### DIFF
--- a/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
+++ b/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
@@ -36,10 +36,10 @@ You need to be an admin of your Mistral Organization to configure the Slack inte
 2. **Make sure you are in the right Mistral organization.** Your Mistral organization can only be connected to a single Slack Workspace.
 3. In **App Connections** section, click **Connect to Slack**.
 4. Complete the OAuth flow to finalise the connection. If you are not an owner of your Slack workspace, you may need to request app installation from a workspace owner.
-5. **Mistral Vibe** is now installed in your Slack workspace. You can now [start your first session](#start-first-session).
+5. **Mistral Vibe** is now installed in your Slack workspace. You can now [connect to Slack MCP](#slack-mcp-usage) or [start your first session](#start-first-session).
 
-<SectionTab as="h1" sectionId="configuration">
-  Using Slack MCP
+<SectionTab as="h1" sectionId="slack-mcp-usage">
+  Use Slack MCP
 </SectionTab>
 
 You are all setup to use Slack MCP. From there, please follow these instructions:
@@ -96,8 +96,8 @@ Use Slack when the coding task starts from:
 
 Use prompts that are scoped, actionable, and likely to end in a branch or pull request.
 
-| Use case                           | Slack prompt                                                                                                                                                |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Use case                           | Slack prompt                                                                                                                                         |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Investigate a failing test**     | `@Vibe investigate the failing test in this thread. If the fix is clear, open a PR with the smallest safe change.`                                   |
 | **Fix a customer-reported bug**    | `@Vibe use the customer report above to find the likely bug. Open a PR if you can reproduce or identify a clear fix.`                                |
 | **Address an alert**               | `@Vibe investigate this alert and check whether there is a code or config fix. Start with a summary, then open a PR only if the change is low risk.` |

--- a/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
+++ b/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
@@ -26,10 +26,6 @@ Use this guide after the Vibe Code Web Slack app has been installed and connecte
 
 :::warning
 You need to be an admin of your Mistral Organization to configure the Slack integration.
-
-<CtaButton href="https://admin.mistral.ai/organization/connectors">
-  Open Admin settings
-</CtaButton>
 :::
 
 1. Open [**Admin Settings**](https://admin.mistral.ai/organization/connectors)
@@ -42,7 +38,7 @@ You need to be an admin of your Mistral Organization to configure the Slack inte
   Use Slack MCP
 </SectionTab>
 
-You are all setup to use Slack MCP. From there, please follow these instructions:
+Once Slack App is installed to your Slack workspace, please follow these instructions:
 
 1. Open [**Vibe Work**](https://chat.mistral.ai/connections)
 2. Click on **Slack Connector**, then click **Connect**

--- a/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
+++ b/src/app/(docs)/(products)/vibe/code/vibe-code-web/slack-integration/page.mdx
@@ -8,6 +8,16 @@ import { CtaButton } from '@/components/common/cta-button';
 
 # Vibe Code Web for Slack: Quickstart
 
+:::info
+**AI-generated content:** This app uses AI to generate responses and code. Outputs may be inaccurate, incomplete, or misleading. Do not rely on them as factual, legal, medical, financial, or professional advice. Always verify important information independently. See our [privacy policy](https://mistral.ai/terms#privacy-policy).
+:::
+
+Vibe Code Web for Slack lets your team start remote AI coding sessions directly from a Slack thread. The agent reads the thread context, works in an isolated cloud sandbox, and opens a GitHub pull request — without leaving Slack.
+
+<CtaButton href="https://admin.mistral.ai/organization/connectors">
+  Connect Slack to your Mistral Organization
+</CtaButton>
+
 Use this guide after the Vibe Code Web Slack app has been installed and connected to your Vibe account and GitHub repositories.
 
 <SectionTab as="h1" sectionId="configuration">
@@ -26,7 +36,7 @@ You need to be an admin of your Mistral Organization to configure the Slack inte
 2. **Make sure you are in the right Mistral organization.** Your Mistral organization can only be connected to a single Slack Workspace.
 3. In **App Connections** section, click **Connect to Slack**.
 4. Complete the OAuth flow to finalise the connection. If you are not an owner of your Slack workspace, you may need to request app installation from a workspace owner.
-5. **Mistral Vibe** is now installed in your Slack workspace.
+5. **Mistral Vibe** is now installed in your Slack workspace. You can now [start your first session](#start-first-session).
 
 <SectionTab as="h1" sectionId="configuration">
   Using Slack MCP
@@ -182,3 +192,11 @@ Avoid Slack-triggered sessions for:
 - vague prompts like _"fix this"_ without logs or expected behavior
 - cross-owner GitHub work unless the project and repo mapping is clear
 - changes that should be manually designed before implementation
+
+<SectionTab as="h1" sectionId="data-privacy">
+  Data & privacy
+</SectionTab>
+
+- Vibe Code Web for Slack uses AI to generate code, summaries, and pull requests. Outputs may be inaccurate — always review before merging.
+- Slack thread content shared with the app is processed to fulfill your request and is not used to train Mistral models.
+- For full details on data handling, retention, and your rights, see the [Mistral privacy policy](https://mistral.ai/terms#privacy-policy) and [trust center](https://trust.mistral.ai/).


### PR DESCRIPTION
## Changes

Addresses the Slack Marketplace [landing page guidelines](https://docs.slack.dev/slack-marketplace/slack-marketplace-app-guidelines-and-requirements/#landing) and [AI components requirements](https://docs.slack.dev/slack-marketplace/slack-marketplace-app-guidelines-and-requirements/#ai-components).

### What changed

| Requirement | Fix |
|---|---|
| **AI disclaimer on landing page** | Added a prominent `:::info` callout at the very top of the page with the disclaimer and a link to the privacy policy |
| **Clear install path / CTA** | Added an app overview paragraph and a `CtaButton` above the fold pointing to Admin Settings |
| **Post-install next steps** | Step 5 of Configuration now links directly to the 'Start your first session' section |
| **Privacy policy link** | Added a new 'Data & privacy' section at the bottom with links to `mistral.ai/terms#privacy-policy` and `trust.mistral.ai` |

### Not addressed (requires product assets)
- Screenshots/GIFs of the Slack experience