### PR TITLE
fix(search-toolkit): fix all relative links

### DIFF
--- a/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/ingestion/page.mdx
+++ b/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/ingestion/page.mdx
@@ -159,9 +159,9 @@ document = await router.run_file(file=file)
 
 Each ingestion component is documented in detail with configuration options, best practices, and examples:
 
-- **[File loaders](loaders)** — Load files from filesystem, cloud storage, or custom sources
-- **[Document extractors](extractors)** — Extract content from PDFs, HTML, spreadsheets, and more (7 formats supported)
-- **[Text splitters](splitters)** — Divide documents into chunks with optimal size and overlap
-- **[Chunk enrichers](enrichers)** — Add custom metadata for filtering and ranking
-- **[Embedders](embedders)** — Convert text to vectors for semantic search
-- **[Search index](../search-index)** — Store and search over indexed chunks
+- **[File loaders](ingestion/loaders)** — Load files from filesystem, cloud storage, or custom sources
+- **[Document extractors](ingestion/extractors)** — Extract content from PDFs, HTML, spreadsheets, and more (7 formats supported)
+- **[Text splitters](ingestion/splitters)** — Divide documents into chunks with optimal size and overlap
+- **[Chunk enrichers](ingestion/enrichers)** — Add custom metadata for filtering and ranking
+- **[Embedders](ingestion/embedders)** — Convert text to vectors for semantic search
+- **[Search index](search-index)** — Store and search over indexed chunks

--- a/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/page.mdx
+++ b/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/page.mdx
@@ -14,7 +14,7 @@ LLMs are not trained on your private data. To ground their answers in your docum
 
 <SectionTab as="h1" sectionId="key-features">Key features</SectionTab>
 
-### [Ingestion](ingestion)
+### [Ingestion](search-toolkit/ingestion)
 
 - **Multi-format extraction**: PDF/DOCX/PPTX via Mistral OCR, HTML, spreadsheets, emails, plain text
 - **File loading**: Load from the local filesystem or implement custom loaders for any source
@@ -22,7 +22,7 @@ LLMs are not trained on your private data. To ground their answers in your docum
 - **Enrichment**: Enrich documents and chunks with custom metadata or LLM-generated summaries
 - **Indexing**: Index to vector stores for semantic search
 
-### [Retrieval](retrieval)
+### [Retrieval](search-toolkit/retrieval)
 
 - **Multiple strategies**: Vector (semantic) search with optional reranking
 - **Query preprocessing**: Improve user queries with LLM reformulation or query extension
@@ -91,7 +91,7 @@ Requires **Python 3.12+**. We recommend using [uv](https://docs.astral.sh/uv/) f
 
 <SectionTab as="h1" sectionId="next-steps">Next steps</SectionTab>
 
-- **[Quickstart](quickstart)** — build your first ingestion and retrieval pipeline end to end.
-- **[Search index](search-index)** — set up your vector store.
-- **[Ingestion](ingestion)** — load, extract, chunk, enrich, and index your documents.
-- **[Retrieval](retrieval)** — configure vector search with optional reranking.
+- **[Quickstart](search-toolkit/quickstart)** — build your first ingestion and retrieval pipeline end to end.
+- **[Search index](search-toolkit/search-index)** — set up your vector store.
+- **[Ingestion](search-toolkit/ingestion)** — load, extract, chunk, enrich, and index your documents.
+- **[Retrieval](search-toolkit/retrieval)** — configure vector search with optional reranking.

--- a/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/quickstart/page.mdx
+++ b/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/quickstart/page.mdx
@@ -80,7 +80,7 @@ class InitialSchema(VespaMigration):
         )
 ```
 
-For more details on Vespa application management and deployment, see [Manage and deploy Vespa applications](../vespa).
+For more details on Vespa application management and deployment, see [Manage and deploy Vespa applications](vespa).
 
 <SectionTab as="h1" sectionId="deploy-schema">Deploy from migrations</SectionTab>
 

--- a/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/retrieval/page.mdx
+++ b/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/retrieval/page.mdx
@@ -46,7 +46,7 @@ print(f"Results: {len(result.results)}")
 
 Each retrieval component is documented in detail with examples and best practices:
 
-- **[Retrievers](retrievers)** — VectorRetriever, KeywordRetriever, and hybrid search patterns
-- **[Rerankers](rerankers)** — LLMReRanker, CrossEncoderReRanker, RRF fusion, and custom rerankers
-- **[Query preprocessing](preprocessing)** — Query rewriting and expansion for better retrieval quality
-- **[Semantic cache](semantic-cache)** — Cache results by query similarity to reduce latency
+- **[Retrievers](retrieval/retrievers)** — VectorRetriever, KeywordRetriever, and hybrid search patterns
+- **[Rerankers](retrieval/rerankers)** — LLMReRanker, CrossEncoderReRanker, RRF fusion, and custom rerankers
+- **[Query preprocessing](retrieval/preprocessing)** — Query rewriting and expansion for better retrieval quality
+- **[Semantic cache](retrieval/semantic-cache)** — Cache results by query similarity to reduce latency

--- a/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/retrieval/preprocessing/page.mdx
+++ b/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/retrieval/preprocessing/page.mdx
@@ -239,7 +239,7 @@ query_engine = QueryEngine(
 
 <SectionTab as="h1" sectionId="see-also">See also</SectionTab>
 
-- [Retrieval overview](../) — Retrieval pipeline architecture
-- [Retrievers](../retrievers) — Vector and keyword search
-- [Rerankers](../rerankers) — Refine results after retrieval
-- [Semantic cache](../semantic-cache) — Cache preprocessed queries
+- [Retrieval overview](../retrieval) — Retrieval pipeline architecture
+- [Retrievers](retrievers) — Vector and keyword search
+- [Rerankers](rerankers) — Refine results after retrieval
+- [Semantic cache](semantic-cache) — Cache preprocessed queries

--- a/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/retrieval/rerankers/page.mdx
+++ b/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/retrieval/rerankers/page.mdx
@@ -305,6 +305,6 @@ result = await query_engine.search(query="...", top_k=10)
 
 <SectionTab as="h1" sectionId="see-also">See also</SectionTab>
 
-- [Retrieval overview](../) — Retrieval pipeline architecture
-- [Retrievers](../retrievers) — Vector search and custom retrievers
-- [Query preprocessing](../preprocessing) — Improve queries before retrieval
+- [Retrieval overview](../retrieval) — Retrieval pipeline architecture
+- [Retrievers](retrievers) — Vector search and custom retrievers
+- [Query preprocessing](preprocessing) — Improve queries before retrieval

--- a/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/retrieval/retrievers/page.mdx
+++ b/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/retrieval/retrievers/page.mdx
@@ -115,6 +115,6 @@ query_engine = QueryEngine(retriever=CustomRetriever())
 
 <SectionTab as="h1" sectionId="see-also">See also</SectionTab>
 
-- [Retrieval overview](../) — Retrieval pipeline architecture
-- [Rerankers](../rerankers) — Re-score results for better ranking
-- [Query preprocessing](../preprocessing) — Improve queries before retrieval
+- [Retrieval overview](../retrieval) — Retrieval pipeline architecture
+- [Rerankers](rerankers) — Re-score results for better ranking
+- [Query preprocessing](preprocessing) — Improve queries before retrieval

--- a/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/retrieval/semantic-cache/page.mdx
+++ b/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/retrieval/semantic-cache/page.mdx
@@ -302,7 +302,7 @@ similarity_threshold=0.90
 
 <SectionTab as="h1" sectionId="see-also">See also</SectionTab>
 
-- [Retrieval overview](../) — Retrieval pipeline architecture
-- [Retrievers](../retrievers) — Vector search
-- [Rerankers](../rerankers) — Refine results after retrieval
-- [Query preprocessing](../preprocessing) — Improve queries before retrieval
+- [Retrieval overview](../retrieval) — Retrieval pipeline architecture
+- [Retrievers](retrievers) — Vector search
+- [Rerankers](rerankers) — Refine results after retrieval
+- [Query preprocessing](preprocessing) — Improve queries before retrieval

--- a/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/search-index/page.mdx
+++ b/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/search-index/page.mdx
@@ -23,7 +23,7 @@ Storage backends persist processed chunks and enable efficient search across you
 Use Vespa as a vector store in Search Toolkit ingestion and retrieval pipelines. Vespa provides scalable vector search with schema management, ranking, and production-ready clustering.
 
 :::info
-**Requirement**: You must have a **running Vespa application** before connecting with this search index. See **[Manage and deploy Vespa](../vespa)** to define schemas and deploy your application first.
+**Requirement**: You must have a **running Vespa application** before connecting with this search index. See **[Manage and deploy Vespa](vespa)** to define schemas and deploy your application first.
 :::
 
 **Features**:
@@ -45,7 +45,7 @@ Before using Vespa as a search index:
 2. **Deploy Vespa** — Run `mistral-vespa migrate` to deploy your application
 3. **Get the endpoint** — Note the Vespa query endpoint (e.g., `http://localhost:8080`)
 
-See **[Manage and deploy Vespa](../vespa)** for complete setup instructions.
+See **[Manage and deploy Vespa](vespa)** for complete setup instructions.
 
 ### Quick start
 
@@ -93,7 +93,7 @@ query_engine = QueryEngine(
 result = await query_engine.search(query="What is RAG?", top_k=5)
 ```
 
-For comprehensive setup, schema design, and operations, see **[Manage and deploy Vespa](../vespa)**.
+For comprehensive setup, schema design, and operations, see **[Manage and deploy Vespa](vespa)**.
 
 <SectionTab as="h1" sectionId="custom-vector-stores">Custom vector stores</SectionTab>
 

--- a/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/vespa/anatomy/page.mdx
+++ b/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/vespa/anatomy/page.mdx
@@ -5,7 +5,7 @@ sidebar_label: Anatomy of an application
 ---
 import { SectionTab } from '@/components/layout/section-tab';
 
-This page explains the concepts that make up a Vespa application: the application package, schemas, fields, ranking profiles, and query profiles. To learn how to create and configure these, see [Manage Schema](../migrations).
+This page explains the concepts that make up a Vespa application: the application package, schemas, fields, ranking profiles, and query profiles. To learn how to create and configure these, see [Manage Schema](migrations).
 
 <SectionTab as="h2" sectionId="application-package">Application Package</SectionTab>
 
@@ -21,7 +21,7 @@ A Vespa application package is a set of configuration files that tell the cluste
         └── types/root.xml        # Query profile types
 ```
 
-You never write these files by hand. They are built in memory from your [migrations](../migrations) and uploaded to the Vespa cluster. You can inspect them with `mistral-vespa generate` (see [CLI reference](../cli)).
+You never write these files by hand. They are built in memory from your [migrations](migrations) and uploaded to the Vespa cluster. You can inspect them with `mistral-vespa generate` (see [CLI reference](cli)).
 
 <SectionTab as="h2" sectionId="migrations-building-the-application-package">Migrations: Building the Application Package</SectionTab>
 
@@ -121,9 +121,9 @@ The plugin generates one query profile per schema (named via `default_query_prof
 - The `weighted-rank2` ranking profile as default
 - Query type fields for function weights
 
-For more, see [Query Profiles](../query-profiles) and the [Vespa documentation on query profiles](https://docs.vespa.ai/en/querying/query-profiles.html).
+For more, see [Query Profiles](query-profiles) and the [Vespa documentation on query profiles](https://docs.vespa.ai/en/querying/query-profiles.html).
 
 <SectionTab as="h2" sectionId="see-also">See Also</SectionTab>
 
-- **[Manage Schema](../migrations)** — How to create schemas, fields, and ranking via migrations
-- **[Manage Ranking](../query-profiles)** — Configure ranking at query time
+- **[Manage Schema](migrations)** — How to create schemas, fields, and ranking via migrations
+- **[Manage Ranking](query-profiles)** — Configure ranking at query time

--- a/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/vespa/local-development/page.mdx
+++ b/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/vespa/local-development/page.mdx
@@ -5,7 +5,7 @@ sidebar_label: Local development
 ---
 import { SectionTab } from '@/components/layout/section-tab';
 
-This guide covers the full local development loop: create a schema, deploy locally, feed and query documents, then iterate with new migrations. See [Manage Schema](../migrations) to learn how to manage schemas and the [CLI reference](../cli) for the full set of flags.
+This guide covers the full local development loop: create a schema, deploy locally, feed and query documents, then iterate with new migrations. See [Manage Schema](migrations) to learn how to manage schemas and the [CLI reference](cli) for the full set of flags.
 
 <SectionTab as="h2" sectionId="prerequisites">Prerequisites</SectionTab>
 
@@ -187,4 +187,4 @@ Use an IDE with the Vespa plugin for syntax highlighting, code completion, navig
 
 <SectionTab as="h2" sectionId="see-also">See Also</SectionTab>
 
-- **[Deploy and Operate](../operations)** — Production deployment and health checks
+- **[Deploy and Operate](operations)** — Production deployment and health checks

--- a/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/vespa/migrations/page.mdx
+++ b/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/vespa/migrations/page.mdx
@@ -5,7 +5,7 @@ sidebar_label: Manage schema
 ---
 import { SectionTab } from '@/components/layout/section-tab';
 
-Manage your Vespa application schemas through Python migrations. For the concepts behind schemas, fields, and ranking, see [Anatomy of a Vespa application](../anatomy).
+Manage your Vespa application schemas through Python migrations. For the concepts behind schemas, fields, and ranking, see [Anatomy of a Vespa application](anatomy).
 
 <SectionTab as="h2" sectionId="creating-and-evolving-schemas">Creating and Evolving Schemas</SectionTab>
 
@@ -91,7 +91,7 @@ Call `create_schema()` or `create_default_schema()` multiple times to register m
 
 <SectionTab as="h2" sectionId="deploying">Deploying</SectionTab>
 
-`mistral-vespa migrate` discovers migrations, runs them in order, builds the app package, and uploads it. See the [Local Development](../local-development) and [Deploy and Operate](../operations) guides for details.
+`mistral-vespa migrate` discovers migrations, runs them in order, builds the app package, and uploads it. See the [Local Development](local-development) and [Deploy and Operate](operations) guides for details.
 
 <SectionTab as="h2" sectionId="optional-snapshot">Optional Snapshot</SectionTab>
 
@@ -105,6 +105,6 @@ Writes the app package to disk for inspection or CI validation. It is not used f
 
 <SectionTab as="h2" sectionId="see-also">See Also</SectionTab>
 
-- **[Anatomy of a Vespa application](../anatomy)** — Concepts: schemas, fields, ranking profiles, migrations
-- **[Local Development](../local-development)** — Full local development loop
-- **[CLI reference](../cli)** — Full set of CLI flags
+- **[Anatomy of a Vespa application](anatomy)** — Concepts: schemas, fields, ranking profiles, migrations
+- **[Local Development](local-development)** — Full local development loop
+- **[CLI reference](cli)** — Full set of CLI flags

--- a/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/vespa/operations/page.mdx
+++ b/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/vespa/operations/page.mdx
@@ -135,6 +135,6 @@ vector_store = app.get_search_index(config, collection_name="my_collection")
 
 <SectionTab as="h2" sectionId="see-also">See Also</SectionTab>
 
-- **[Local Development](../local-development)** — Local setup guide
-- **[Manage with Migrations](../migrations)** — Create and evolve schemas
+- **[Local Development](local-development)** — Local setup guide
+- **[Manage with Migrations](migrations)** — Create and evolve schemas
 - **[Vespa official docs](https://docs.vespa.ai)** — Advanced configuration and operations

--- a/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/vespa/page.mdx
+++ b/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/vespa/page.mdx
@@ -16,16 +16,16 @@ Follow these guides to build and deploy a Vespa application:
 
 | Guide | Purpose |
 |---|---|
-| **[Anatomy of an Application](anatomy)** | Understand application packages, schemas, fields, ranking profiles, query profiles, and migrations |
-| **[Manage Schema](migrations)** | Create and evolve schemas using Python migrations |
-| **[Manage Ranking](query-profiles)** | Configure ranking at query time without schema changes |
-| **[Local Development](local-development)** | Full local development loop: create, deploy, feed, query, iterate |
-| **[Deploy and Operate](operations)** | Production configuration, health checks, monitoring |
-| **[CLI Reference](cli)** | mistral-vespa command reference |
+| **[Anatomy of an Application](vespa/anatomy)** | Understand application packages, schemas, fields, ranking profiles, query profiles, and migrations |
+| **[Manage Schema](vespa/migrations)** | Create and evolve schemas using Python migrations |
+| **[Manage Ranking](vespa/query-profiles)** | Configure ranking at query time without schema changes |
+| **[Local Development](vespa/local-development)** | Full local development loop: create, deploy, feed, query, iterate |
+| **[Deploy and Operate](vespa/operations)** | Production configuration, health checks, monitoring |
+| **[CLI Reference](vespa/cli)** | mistral-vespa command reference |
 
 <SectionTab as="h2" sectionId="using-vespa-as-a-search-backend">Using Vespa as a Search Backend</SectionTab>
 
-To use Vespa as a search backend in your Search Toolkit pipelines, see **[Search Index](../search-index)**.
+To use Vespa as a search backend in your Search Toolkit pipelines, see **[Search Index](search-index)**.
 
 <SectionTab as="h2" sectionId="installation">Installation</SectionTab>
 

--- a/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/vespa/query-profiles/page.mdx
+++ b/src/content/en/docs/studio-api/knowledge-rag/search-toolkit/vespa/query-profiles/page.mdx
@@ -7,7 +7,7 @@ import { SectionTab } from '@/components/layout/section-tab';
 
 Query profiles let you **control ranking at query time** without modifying your schema. Each profile bundles a ranking profile, function weights, and query parameters into a named configuration that you can switch between requests.
 
-For the concepts behind query profiles, see [Anatomy of a Vespa application](../anatomy).
+For the concepts behind query profiles, see [Anatomy of a Vespa application](anatomy).
 
 <SectionTab as="h2" sectionId="default-query-profile">Default Query Profile</SectionTab>
 
@@ -100,7 +100,7 @@ Each `QueryField` has:
 | Field | Description |
 |---|---|
 | `ranking.profile` | Ranking profile to use (`weighted-rank1`, `weighted-rank2`, `match-only`) |
-| `ranking.features.query(<weight_name>)` | Weight for a ranking function (see [Ranking reference](../anatomy)) |
+| `ranking.features.query(<weight_name>)` | Weight for a ranking function (see [Ranking reference](anatomy)) |
 | `hits` | Number of results to return |
 
 Weight names follow the pattern `<function_name>_weight`. For example, `bm25_title` has weight `bm25_title_weight`.
@@ -170,6 +170,6 @@ When `query_profile` is omitted, the schema's default query profile is used auto
 
 <SectionTab as="h2" sectionId="see-also">See Also</SectionTab>
 
-- **[Anatomy of a Vespa application](../anatomy)** — Query profiles concept
-- **[Manage Schema](../migrations)** — Migration system and helpers
+- **[Anatomy of a Vespa application](anatomy)** — Query profiles concept
+- **[Manage Schema](migrations)** — Migration system and helpers
 - **[Vespa query profiles documentation](https://docs.vespa.ai/en/querying/query-profiles.html)** — Official Vespa guide

--- a/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/ingestion/page.mdx
+++ b/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/ingestion/page.mdx
@@ -321,9 +321,9 @@ document = await router.run_file(file=file)
 
 Chaque composant d'ingestion est documenté en détail, avec les options de configuration, les bonnes pratiques et de nombreux exemples :
 
-- **[Loaders de fichiers](loaders)** — Chargez des fichiers depuis le système de fichiers, un stockage cloud ou des sources personnalisées
-- **[Extracteurs de documents](extractors)** — Extrait le contenu de PDF, HTML, tableurs et autres (7 formats pris en charge)
-- **[Diviseurs de texte](splitters)** — Découpent les documents en fragments de taille et de recouvrement optimaux
-- **[Enrichisseurs de fragment](enrichers)** — Ajoutent des métadonnées personnalisées pour le filtrage et le classement
-- **[Embedders](embedders)** — Convertissent le texte en vecteurs pour la recherche sémantique
-- **[Index de recherche](../search-index)** — Stocke et permet la recherche parmi les fragments indexés
+- **[Loaders de fichiers](ingestion/loaders)** — Chargez des fichiers depuis le système de fichiers, un stockage cloud ou des sources personnalisées
+- **[Extracteurs de documents](ingestion/extractors)** — Extrait le contenu de PDF, HTML, tableurs et autres (7 formats pris en charge)
+- **[Diviseurs de texte](ingestion/splitters)** — Découpent les documents en fragments de taille et de recouvrement optimaux
+- **[Enrichisseurs de fragment](ingestion/enrichers)** — Ajoutent des métadonnées personnalisées pour le filtrage et le classement
+- **[Embedders](ingestion/embedders)** — Convertissent le texte en vecteurs pour la recherche sémantique
+- **[Index de recherche](search-index)** — Stocke et permet la recherche parmi les fragments indexés

--- a/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/page.mdx
+++ b/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/page.mdx
@@ -14,7 +14,7 @@ Les LLM ne sont pas entraînés sur vos données privées. Pour que leurs répon
 
 <SectionTab as="h1" sectionId="key-features">Fonctionnalités clés</SectionTab>
 
-### [Ingestion](ingestion)
+### [Ingestion](search-toolkit/ingestion)
 
 - **Extraction multi-format** : PDF/DOCX/PPTX via Mistral OCR, HTML, tableurs, e-mails, texte brut
 - **Chargement de fichiers** : depuis le système de fichiers local ou via des loaders personnalisés pour toute source
@@ -22,7 +22,7 @@ Les LLM ne sont pas entraînés sur vos données privées. Pour que leurs répon
 - **Enrichissement** : ajoutez des métadonnées personnalisées ou des résumés générés par LLM sur vos documents et fragments
 - **Indexation** : indexez dans des bases vectorielles pour la recherche sémantique
 
-### [Récupération](retrieval)
+### [Récupération](search-toolkit/retrieval)
 
 - **Stratégies multiples** : recherche vectorielle (sémantique) avec reranking optionnel
 - **Prétraitement des requêtes** : améliorez les requêtes utilisateur avec reformulation ou extension par LLM
@@ -91,7 +91,7 @@ Nécessite **Python 3.12+**. Nous recommandons [uv](https://docs.astral.sh/uv/) 
 
 <SectionTab as="h1" sectionId="next-steps">Prochaines étapes</SectionTab>
 
-- **[Guide de démarrage](quickstart)** : créez un pipeline ingestion/récupération de bout en bout.
-- **[Index de recherche](search-index)** : configurez votre base vectorielle.
-- **[Ingestion](ingestion)** : chargez, extrayez, fragmentez, enrichissez et indexez vos documents.
-- **[Récupération](retrieval)** : configurez la recherche vectorielle et le reranking optionnel.
+- **[Guide de démarrage](search-toolkit/quickstart)** : créez un pipeline ingestion/récupération de bout en bout.
+- **[Index de recherche](search-toolkit/search-index)** : configurez votre base vectorielle.
+- **[Ingestion](search-toolkit/ingestion)** : chargez, extrayez, fragmentez, enrichissez et indexez vos documents.
+- **[Récupération](search-toolkit/retrieval)** : configurez la recherche vectorielle et le reranking optionnel.

--- a/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/quickstart/page.mdx
+++ b/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/quickstart/page.mdx
@@ -80,7 +80,7 @@ class InitialSchema(VespaMigration):
         )
 ```
 
-Pour obtenir plus de détails sur la gestion et le déploiement d’applications Vespa, consultez [Gérer et déployer des applications Vespa](../vespa).
+Pour obtenir plus de détails sur la gestion et le déploiement d’applications Vespa, consultez [Gérer et déployer des applications Vespa](vespa).
 
 <SectionTab as="h1" sectionId="deploy-schema">Déployer à partir des migrations</SectionTab>
 

--- a/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/retrieval/page.mdx
+++ b/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/retrieval/page.mdx
@@ -46,7 +46,7 @@ print(f"Results: {len(result.results)}")
 
 Chaque composant du pipeline de recherche est documenté en détail avec exemples et bonnes pratiques :
 
-- **[Retrievers](retrievers)** — VectorRetriever, KeywordRetriever et patterns hybrides
-- **[Rerankers](rerankers)** — LLMReRanker, CrossEncoderReRanker, fusion RRF et rerankers personnalisés
-- **[Prétraitement des requêtes](preprocessing)** — Réécriture et expansion des requêtes pour améliorer la qualité de la recherche
-- **[Cache sémantique](semantic-cache)** — Mise en cache des résultats par similarité de requête pour réduire la latence
+- **[Retrievers](retrieval/retrievers)** — VectorRetriever, KeywordRetriever et patterns hybrides
+- **[Rerankers](retrieval/rerankers)** — LLMReRanker, CrossEncoderReRanker, fusion RRF et rerankers personnalisés
+- **[Prétraitement des requêtes](retrieval/preprocessing)** — Réécriture et expansion des requêtes pour améliorer la qualité de la recherche
+- **[Cache sémantique](retrieval/semantic-cache)** — Mise en cache des résultats par similarité de requête pour réduire la latence

--- a/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/retrieval/preprocessing/page.mdx
+++ b/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/retrieval/preprocessing/page.mdx
@@ -286,7 +286,7 @@ query_engine = QueryEngine(
 
 <SectionTab as="h1" sectionId="see-also">À voir aussi</SectionTab>
 
-- [Présentation de la recherche](../) — Architecture de la pipeline de recherche
-- [Moteurs de recherche](../retrievers) — Recherche vectorielle et par mot-clé
-- [Reclasseurs](../rerankers) — Affiner les résultats après la recherche
-- [Cache sémantique](../semantic-cache) — Mise en cache des requêtes prétraitées
+- [Présentation de la recherche](../retrieval) — Architecture de la pipeline de recherche
+- [Moteurs de recherche](retrievers) — Recherche vectorielle et par mot-clé
+- [Reclasseurs](rerankers) — Affiner les résultats après la recherche
+- [Cache sémantique](semantic-cache) — Mise en cache des requêtes prétraitées

--- a/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/retrieval/rerankers/page.mdx
+++ b/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/retrieval/rerankers/page.mdx
@@ -386,6 +386,6 @@ result = await query_engine.search(query="...", top_k=10)
 
 <SectionTab as="h1" sectionId="see-also">Voir aussi</SectionTab>
 
-- [Présentation de la retrieval](../) — Architecture du pipeline de retrieval
-- [Retrieveurs](../retrievers) — Recherche vectorielle et retrieveurs personnalisés
-- [Prétraitement des requêtes](../preprocessing) — Améliorer les requêtes avant retrieval
+- [Présentation de la retrieval](../retrieval) — Architecture du pipeline de retrieval
+- [Retrieveurs](retrievers) — Recherche vectorielle et retrieveurs personnalisés
+- [Prétraitement des requêtes](preprocessing) — Améliorer les requêtes avant retrieval

--- a/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/retrieval/retrievers/page.mdx
+++ b/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/retrieval/retrievers/page.mdx
@@ -183,6 +183,6 @@ query_engine = QueryEngine(retriever=CustomRetriever())
 
 <SectionTab as="h1" sectionId="see-also">Voir aussi</SectionTab>
 
-- [Présentation de la retrieval](../) — Architecture du pipeline de retrieval
-- [Rerankers](../rerankers) — Réordonnez les résultats pour un meilleur classement
-- [Prétraitement des requêtes](../preprocessing) — Améliorez les requêtes avant la recherche
+- [Présentation de la retrieval](../retrieval) — Architecture du pipeline de retrieval
+- [Rerankers](rerankers) — Réordonnez les résultats pour un meilleur classement
+- [Prétraitement des requêtes](preprocessing) — Améliorez les requêtes avant la recherche

--- a/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/retrieval/semantic-cache/page.mdx
+++ b/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/retrieval/semantic-cache/page.mdx
@@ -380,7 +380,7 @@ similarity_threshold=0.90
 
 <SectionTab as="h1" sectionId="see-also">Voir aussi</SectionTab>
 
-- [Vue d'ensemble de la récupération](../) — Architecture du pipeline de récupération
-- [Retrievers](../retrievers) — Recherche vectorielle
-- [Rerankers](../rerankers) — Raffinement post-récupération
-- [Prétraitement des requêtes](../preprocessing) — Optimiser la requête avant récupération
+- [Vue d'ensemble de la récupération](../retrieval) — Architecture du pipeline de récupération
+- [Retrievers](retrievers) — Recherche vectorielle
+- [Rerankers](rerankers) — Raffinement post-récupération
+- [Prétraitement des requêtes](preprocessing) — Optimiser la requête avant récupération

--- a/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/search-index/page.mdx
+++ b/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/search-index/page.mdx
@@ -23,7 +23,7 @@ Les backends de stockage conservent les fragments traités et permettent une rec
 Utilisez Vespa comme base vectorielle dans les pipelines d’ingestion et de recherche du Search Toolkit. Vespa propose une recherche vectorielle évolutive, la gestion des schémas, le ranking et la mise en cluster prête pour la production.
 
 :::info
-**Pré-requis** : Une **application Vespa en cours d’exécution** est requise avant de connecter cet index de recherche. Consultez **[Gérer et déployer Vespa](../vespa)** pour définir les schémas et déployer votre application au préalable.
+**Pré-requis** : Une **application Vespa en cours d’exécution** est requise avant de connecter cet index de recherche. Consultez **[Gérer et déployer Vespa](vespa)** pour définir les schémas et déployer votre application au préalable.
 :::
 
 **Fonctionnalités :**
@@ -45,7 +45,7 @@ Avant d’utiliser Vespa comme index de recherche :
 2. **Déployer Vespa** — Exécutez `mistral-vespa migrate` pour déployer votre application
 3. **Obtenir l’endpoint** — Notez l’endpoint de requête Vespa (ex. : `http://localhost:8080`)
 
-Consultez **[Gérer et déployer Vespa](../vespa)** pour les instructions complètes de configuration.
+Consultez **[Gérer et déployer Vespa](vespa)** pour les instructions complètes de configuration.
 
 ### Guide de démarrage
 
@@ -93,7 +93,7 @@ query_engine = QueryEngine(
 result = await query_engine.search(query="What is RAG?", top_k=5)
 ```
 
-Pour une configuration complète, la conception des schémas et les opérations, consultez **[Gérer et déployer Vespa](../vespa)**.
+Pour une configuration complète, la conception des schémas et les opérations, consultez **[Gérer et déployer Vespa](vespa)**.
 
 <SectionTab as="h1" sectionId="custom-vector-stores">Bases vectorielles personnalisées</SectionTab>
 

--- a/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/vespa/anatomy/page.mdx
+++ b/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/vespa/anatomy/page.mdx
@@ -5,7 +5,7 @@ sidebar_label: Anatomie d’une application
 ---
 import { SectionTab } from '@/components/layout/section-tab';
 
-Cette page présente les concepts qui composent une application Vespa : le package d’application, les schémas, les champs, les profils de ranking et les profils de requête. Pour apprendre à les créer et les configurer, consultez [Gérer les schémas](../migrations).
+Cette page présente les concepts qui composent une application Vespa : le package d’application, les schémas, les champs, les profils de ranking et les profils de requête. Pour apprendre à les créer et les configurer, consultez [Gérer les schémas](migrations).
 
 <SectionTab as="h2" sectionId="application-package">Package d’application</SectionTab>
 
@@ -21,7 +21,7 @@ Un package d’application Vespa est un ensemble de fichiers de configuration qu
         └── types/root.xml        # Types de profils de requête
 ```
 
-Vous n’écrivez jamais ces fichiers manuellement. Ils sont générés en mémoire à partir de vos [migrations](../migrations) et téléchargés sur le cluster Vespa. Vous pouvez les inspecter avec `mistral-vespa generate` (voir [référence CLI](../cli)).
+Vous n’écrivez jamais ces fichiers manuellement. Ils sont générés en mémoire à partir de vos [migrations](migrations) et téléchargés sur le cluster Vespa. Vous pouvez les inspecter avec `mistral-vespa generate` (voir [référence CLI](cli)).
 
 <SectionTab as="h2" sectionId="migrations-building-the-application-package">Migrations : génération du package d’application</SectionTab>
 
@@ -121,9 +121,9 @@ Le plugin crée un profil de requête par schéma (nommé via `default_query_pro
 - Le profil de ranking `weighted-rank2` en valeur par défaut
 - Des champs de type « query » pour pondérer les fonctions
 
-Pour plus d’informations, voir [Profils de requête](../query-profiles) et la [documentation Vespa sur les profils de requête](https://docs.vespa.ai/en/querying/query-profiles.html).
+Pour plus d’informations, voir [Profils de requête](query-profiles) et la [documentation Vespa sur les profils de requête](https://docs.vespa.ai/en/querying/query-profiles.html).
 
 <SectionTab as="h2" sectionId="see-also">Voir aussi</SectionTab>
 
-- **[Gérer les schémas](../migrations)** : Création de schémas, champs et ranking via des migrations
-- **[Gérer le ranking](../query-profiles)** : Configurer le ranking à la requête
+- **[Gérer les schémas](migrations)** : Création de schémas, champs et ranking via des migrations
+- **[Gérer le ranking](query-profiles)** : Configurer le ranking à la requête

--- a/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/vespa/local-development/page.mdx
+++ b/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/vespa/local-development/page.mdx
@@ -5,7 +5,7 @@ sidebar_label: Développement local
 ---
 import { SectionTab } from '@/components/layout/section-tab';
 
-Ce guide détaille le cycle complet du développement local : création d'un schéma, déploiement en local, alimentation et requête de documents, puis itération avec de nouvelles migrations. Consultez [Gérer les schémas](../migrations) pour apprendre à gérer les schémas et la [référence CLI](../cli) pour la liste complète des options.
+Ce guide détaille le cycle complet du développement local : création d'un schéma, déploiement en local, alimentation et requête de documents, puis itération avec de nouvelles migrations. Consultez [Gérer les schémas](migrations) pour apprendre à gérer les schémas et la [référence CLI](cli) pour la liste complète des options.
 
 <SectionTab as="h2" sectionId="prerequisites">Prérequis</SectionTab>
 
@@ -187,4 +187,4 @@ Utilisez un IDE avec le plugin Vespa pour la coloration syntaxique, l'autocompl�
 
 <SectionTab as="h2" sectionId="see-also">Voir aussi</SectionTab>
 
-- **[Déployer et opérer](../operations)** — Déploiement en production et vérification de l'état
+- **[Déployer et opérer](operations)** — Déploiement en production et vérification de l'état

--- a/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/vespa/migrations/page.mdx
+++ b/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/vespa/migrations/page.mdx
@@ -5,7 +5,7 @@ sidebar_label: Gérer le schéma
 ---
 import { SectionTab } from '@/components/layout/section-tab';
 
-Gérez les schémas de votre application Vespa à l'aide de migrations Python. Pour comprendre les notions de schéma, de champ et de classement, consultez [Anatomie d'une application Vespa](../anatomy).
+Gérez les schémas de votre application Vespa à l'aide de migrations Python. Pour comprendre les notions de schéma, de champ et de classement, consultez [Anatomie d'une application Vespa](anatomy).
 
 <SectionTab as="h2" sectionId="creating-and-evolving-schemas">Création et évolution des schémas</SectionTab>
 
@@ -91,7 +91,7 @@ Appelez plusieurs fois `create_schema()` ou `create_default_schema()` pour enreg
 
 <SectionTab as="h2" sectionId="deploying">Déploiement</SectionTab>
 
-`mistral-vespa migrate` détecte les migrations, les exécute dans l'ordre, construit le package de l'application et le télécharge. Pour plus de détails, consultez les guides [Développement local](../local-development) et [Déploiement et exploitation](../operations).
+`mistral-vespa migrate` détecte les migrations, les exécute dans l'ordre, construit le package de l'application et le télécharge. Pour plus de détails, consultez les guides [Développement local](local-development) et [Déploiement et exploitation](operations).
 
 <SectionTab as="h2" sectionId="optional-snapshot">Snapshot facultatif</SectionTab>
 
@@ -105,6 +105,6 @@ uv run mistral-vespa generate \
 
 <SectionTab as="h2" sectionId="see-also">Voir aussi</SectionTab>
 
-- **[Anatomie d'une application Vespa](../anatomy)** — Concepts : schémas, champs, profils de classement, migrations
-- **[Développement local](../local-development)** — Boucle complète de développement local
-- **[Référence CLI](../cli)** — Liste complète des options CLI
+- **[Anatomie d'une application Vespa](anatomy)** — Concepts : schémas, champs, profils de classement, migrations
+- **[Développement local](local-development)** — Boucle complète de développement local
+- **[Référence CLI](cli)** — Liste complète des options CLI

--- a/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/vespa/operations/page.mdx
+++ b/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/vespa/operations/page.mdx
@@ -135,6 +135,6 @@ vector_store = app.get_search_index(config, collection_name="my_collection")
 
 <SectionTab as="h2" sectionId="see-also">Voir aussi</SectionTab>
 
-- **[Développement local](../local-development)** — Guide d’installation locale
-- **[Gérer avec les migrations](../migrations)** — Création et évolution des schémas
+- **[Développement local](local-development)** — Guide d’installation locale
+- **[Gérer avec les migrations](migrations)** — Création et évolution des schémas
 - **[Documentation officielle Vespa](https://docs.vespa.ai)** — Paramétrage avancé et exploitation

--- a/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/vespa/page.mdx
+++ b/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/vespa/page.mdx
@@ -16,16 +16,16 @@ Suivez ces guides pour créer et déployer une application Vespa :
 
 | Guide | Objectif |
 |---|---|
-| **[Anatomie d'une application](anatomy)** | Comprendre les packages d'application, les schémas, champs, ranking profiles, query profiles et migrations |
-| **[Gérer les schémas](migrations)** | Créer et faire évoluer les schémas via des migrations Python |
-| **[Gérer le ranking](query-profiles)** | Configurer le ranking à la requête sans modifier le schéma |
-| **[Développement local](local-development)** | Boucle de développement locale complète : création, déploiement, alimentation, requête, itération |
-| **[Déployer et exploiter](operations)** | Configuration production, vérifications de santé, monitoring |
-| **[Référence CLI](cli)** | Référence des commandes mistral-vespa |
+| **[Anatomie d'une application](vespa/anatomy)** | Comprendre les packages d'application, les schémas, champs, ranking profiles, query profiles et migrations |
+| **[Gérer les schémas](vespa/migrations)** | Créer et faire évoluer les schémas via des migrations Python |
+| **[Gérer le ranking](vespa/query-profiles)** | Configurer le ranking à la requête sans modifier le schéma |
+| **[Développement local](vespa/local-development)** | Boucle de développement locale complète : création, déploiement, alimentation, requête, itération |
+| **[Déployer et exploiter](vespa/operations)** | Configuration production, vérifications de santé, monitoring |
+| **[Référence CLI](vespa/cli)** | Référence des commandes mistral-vespa |
 
 <SectionTab as="h2" sectionId="using-vespa-as-a-search-backend">Utiliser Vespa comme backend de recherche</SectionTab>
 
-Pour utiliser Vespa comme backend de recherche dans vos pipelines Search Toolkit, consultez **[Index de recherche](../search-index)**.
+Pour utiliser Vespa comme backend de recherche dans vos pipelines Search Toolkit, consultez **[Index de recherche](search-index)**.
 
 <SectionTab as="h2" sectionId="installation">Installation</SectionTab>
 

--- a/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/vespa/query-profiles/page.mdx
+++ b/src/content/fr/docs/studio-api/knowledge-rag/search-toolkit/vespa/query-profiles/page.mdx
@@ -7,7 +7,7 @@ import { SectionTab } from '@/components/layout/section-tab';
 
 Les profils de requête permettent de **contrôler le ranking à l'exécution d'une requête** sans modifier votre schéma. Chaque profil regroupe un profil de ranking, des poids de fonctions et des paramètres de requête dans une configuration nommée, que vous pouvez sélectionner à chaque requête.
 
-Pour comprendre les concepts liés aux profils de requête, voir [Structure d'une application Vespa](../anatomy).
+Pour comprendre les concepts liés aux profils de requête, voir [Structure d'une application Vespa](anatomy).
 
 <SectionTab as="h2" sectionId="default-query-profile">Profil de requête par défaut</SectionTab>
 
@@ -100,7 +100,7 @@ Chaque `QueryField` comprend :
 | Champ | Description |
 |---|---|
 | `ranking.profile` | Profil de ranking à utiliser (`weighted-rank1`, `weighted-rank2`, `match-only`) |
-| `ranking.features.query(<weight_name>)` | Poids attribué à une fonction de ranking (voir [Référence ranking](../anatomy)) |
+| `ranking.features.query(<weight_name>)` | Poids attribué à une fonction de ranking (voir [Référence ranking](anatomy)) |
 | `hits` | Nombre de résultats à renvoyer |
 
 Les noms de poids respectent le format `<function_name>_weight`. Par exemple, `bm25_title` devient `bm25_title_weight`.
@@ -170,6 +170,6 @@ Si `query_profile` n'est pas renseigné, le profil de requête par défaut du sc
 
 <SectionTab as="h2" sectionId="see-also">Voir aussi</SectionTab>
 
-- **[Structure d'une application Vespa](../anatomy)** — Concept de profils de requête
-- **[Gérer le schéma](../migrations)** — Système de migration et outils associés
+- **[Structure d'une application Vespa](anatomy)** — Concept de profils de requête
+- **[Gérer le schéma](migrations)** — Système de migration et outils associés
 - **[Documentation sur les profils de requête Vespa](https://docs.vespa.ai/en/querying/query-profiles.html)** — Guide officiel Vespa


### PR DESCRIPTION
Fixes broken relative links in all search toolkit pages (EN + FR).

Root cause: Next.js serves pages without trailing slashes, so the browser base URL for `/retrieval` is `search-toolkit/` not `search-toolkit/retrieval/` — bare links like `(retrievers)` resolved one level too high.