### PR TITLE
fix(redirects): remove stale redirects for embedding sub-pages

### DIFF
--- a/redirect.ts
+++ b/redirect.ts
@@ -607,16 +607,6 @@ const rawRedirects: RedirectRule[] = [
     permanent: true,
   },
   {
-    source: "/studio-api/knowledge-rag/embeddings/text_embeddings",
-    destination: "/studio-api/knowledge-rag/embeddings#text-embeddings",
-    permanent: true,
-  },
-  {
-    source: "/studio-api/knowledge-rag/embeddings/code_embeddings",
-    destination: "/studio-api/knowledge-rag/embeddings#code-embeddings",
-    permanent: true,
-  },
-  {
     source: "/studio-api/knowledge-rag/embeddings/rag_quickstart",
     destination: "/studio-api/knowledge-rag/rag_quickstart",
     permanent: true,


### PR DESCRIPTION
## Summary

Removes two stale redirects that were breaking navigation to the Text Embeddings and Code Embeddings pages:

- `/studio-api/knowledge-rag/embeddings/text_embeddings` was redirecting to `embeddings#text-embeddings`
- `/studio-api/knowledge-rag/embeddings/code_embeddings` was redirecting to `embeddings#code-embeddings`

These redirects were added when the sub-pages were merged into the parent page, but `text_embeddings` and `code_embeddings` are now real separate pages again. The redirects were silently bouncing users and sidebar links back to the parent.