### PR TITLE
fix(models): correct "Learn more" deadlink on model selection guide

### DIFF
--- a/src/app/[locale]/(docs)/models/model-selection-guide/_components/benchmark-item.tsx
+++ b/src/app/[locale]/(docs)/models/model-selection-guide/_components/benchmark-item.tsx
@@ -243,7 +243,7 @@ export const BenchmarkTable = ({
             asChild
             className="gap-1 text-sm text-foreground/70 hover:text-foreground"
           >
-            <Link href={`/models/${model.slug}`}>
+            <Link href={modelUrl}>
               {l.text('Learn more about this model', { context: 'Link to the full AI model page' })}
               <ArrowRightIcon className="size-3.5" />
             </Link>


### PR DESCRIPTION
## Summary

- The "Learn more about this model" link at the bottom of the model selection guide pointed to `/models/${model.slug}`, which 404s (e.g. `/models/mistral-medium-3-5-26-04`).
- Switched it to the canonical `getModelUrl` helper — already imported, already computed as `modelUrl`, and already used by the sibling header link — so it resolves to `/models/model-cards/${slug}`.

Reported deadlink: `https://docs.mistral.ai/models/mistral-medium-3-5-26-04`
Correct target: `https://docs.mistral.ai/models/model-cards/mistral-medium-3-5-26-04`

## Test plan

- [x] `pnpm dev` — page compiles
- [x] `/models/model-cards/mistral-medium-3-5-26-04` returns `200` (new link target)
- [x] `/models/mistral-medium-3-5-26-04` returns `404` (old deadlink, now avoided)
- [ ] Manually click "Learn more about this model" at the bottom of the model selection guide and confirm it lands on the model card page