### PR TITLE
ci: replace PUBLIC_DOCS_WRITE_TOKEN with Warden

### DIFF
--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -1,76 +1,16 @@
-# If we tag the docs here we automatically create a PR to the public repo
+# If the public docs repository is tagged, prepare the corresponding update PR.
 
 name: Build and Publish
 
 on:
   push:
-    # We only deploy on tags and main branch
     tags:
-      # Only run on tags that match the following regex
-      # This will match tags like v1.0.0, v1.0.1, etc.
       - v[0-9]+.[0-9]+.[0-9]+
-  
+
 jobs:
   create_pr_on_public:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-        with:
-          token: ${{ secrets.PUBLIC_DOCS_WRITE_TOKEN }}
-          fetch-depth: 0
-          submodules: true
-
-      - name: Pull public updates
-        env: # We cannot use the github bot token to push to the public repo, we have to use one with more permissions
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_DOCS_WRITE_TOKEN }}
-        run: |
-
-          set -x
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "mayo@mistral.ai"
-
-          git remote add public https://github.com/mistralai/platform-docs-public.git
-          git remote update
-          git status
-
-          # Create a diff of the changes, ignoring the ci workflow
-          git merge public/main --no-commit --no-ff --no-edit --allow-unrelated-histories
-
-          # If there are changes, commit them
-          if ! git diff-index --cached --quiet HEAD; then
-            git commit -m "Update from public repo"
-            git push origin ${{github.ref}}
-          else
-            echo "No changes to apply"
-          fi
-
-      - name: Push to public repo
-        env:
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_DOCS_WRITE_TOKEN }}
-        run: |
-          git checkout public/main
-          git checkout -b doc/${{github.ref_name}}
-          
-          # write version number to version file
-          echo ${{github.ref_name}} > version.txt
-
-          git add .
-          git commit -m "Bump version file"
-
-          # create a diff of this ref and the public repo
-          git diff doc/${{github.ref_name}} ${{github.ref_name}} --binary --ignore-submodules=none -- . ':!.github' > changes.diff
-
-          # apply the diff to the current branch
-          git apply changes.diff
-
-          # commit the changes
-          git add .
-          git commit -m "Update version to ${{github.ref_name}}"
-
-          # push the changes
-          git push public doc/${{github.ref_name}}
-
-          # Create a PR from this branch to the public repo
-          gh pr create --title "Update docs to ${{github.ref_name}}" --body "This PR was automatically created by a GitHub Action" --base main --head doc/${{github.ref_name}} --repo mistralai/platform-docs-public
-        
+    permissions:
+      contents: read
+      id-token: write
+    uses: mistralai/platform-docs-public/.github/workflows/publish_tag.yml@main
+    secrets: inherit

--- a/.github/workflows/delete-branch-after-merge.yaml
+++ b/.github/workflows/delete-branch-after-merge.yaml
@@ -8,11 +8,12 @@ jobs:
   delete-branch:
     if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'update-cookbook-submodule'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
-          token: ${{ secrets.PUBLIC_DOCS_WRITE_TOKEN }}
           submodules: true
       - name: Delete Branch
         env:

--- a/.github/workflows/generate_llms_txt.yml
+++ b/.github/workflows/generate_llms_txt.yml
@@ -6,7 +6,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  id-token: write
 
 jobs:
   generate-docs:
@@ -31,11 +32,40 @@ jobs:
       - name: Generate llms.txt & llms-full.txt
         run: python llms_txt/generate_llms_txt.py
 
+      - name: Request public docs Warden token
+        id: warden
+        env:
+          X_PRIVATE_ACCESS_STAGING: ${{ secrets.X_PRIVATE_ACCESS_STAGING }}
+        run: |
+          set -euo pipefail
+
+          OIDC_TOKEN=$(curl --fail --silent --show-error --location \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://warden.globalaegis.net" \
+            | jq -er '.value')
+
+          WARDEN_HEADERS=(
+            -H "Authorization: Bearer $OIDC_TOKEN"
+            -H "Content-Type: application/json"
+            -H "Accept: text/plain"
+          )
+          if [[ -n "${X_PRIVATE_ACCESS_STAGING:-}" ]]; then
+            WARDEN_HEADERS+=( -H "X-Private-Access: $X_PRIVATE_ACCESS_STAGING" )
+          fi
+
+          TOKEN=$(curl --fail-with-body --silent --show-error --location \
+            --request POST https://warden.globalaegis.net/token \
+            "${WARDEN_HEADERS[@]}" \
+            --data '{"type":"github","repository":"platform-docs-public","perms":["contents:write","pull_requests:write"]}')
+
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
       # PR for all changes produced above
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
-          token: ${{ secrets.PUBLIC_DOCS_WRITE_TOKEN }}
+          token: ${{ steps.warden.outputs.token }}
           branch: auto/docs-update
           title: "Auto-update llms.txt & llms-full.txt"
           body: |

--- a/.github/workflows/publish_tag.yml
+++ b/.github/workflows/publish_tag.yml
@@ -1,0 +1,113 @@
+name: Publish tagged docs
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  create_pr_on_public:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate caller ref
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "push" && "$REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            exit 0
+          fi
+
+          echo "Unsupported invocation: event=$EVENT_NAME ref=$REF" >&2
+          exit 1
+
+      - name: Request public docs Warden token
+        id: warden
+        env:
+          X_PRIVATE_ACCESS_STAGING: ${{ secrets.X_PRIVATE_ACCESS_STAGING }}
+        run: |
+          set -euo pipefail
+
+          OIDC_TOKEN=$(curl --fail --silent --show-error --location \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://warden.globalaegis.net" \
+            | jq -er '.value')
+
+          WARDEN_HEADERS=(
+            -H "Authorization: Bearer $OIDC_TOKEN"
+            -H "Content-Type: application/json"
+            -H "Accept: text/plain"
+          )
+          if [[ -n "${X_PRIVATE_ACCESS_STAGING:-}" ]]; then
+            WARDEN_HEADERS+=( -H "X-Private-Access: $X_PRIVATE_ACCESS_STAGING" )
+          fi
+
+          TOKEN=$(curl --fail-with-body --silent --show-error --location \
+            --request POST https://warden.globalaegis.net/token \
+            "${WARDEN_HEADERS[@]}" \
+            --data '{"type":"github","repository":"platform-docs-public","perms":["contents:write","pull_requests:write"]}')
+
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          token: ${{ steps.warden.outputs.token }}
+          fetch-depth: 0
+          submodules: true
+
+      - name: Pull public updates
+        env:
+          GITHUB_TOKEN: ${{ steps.warden.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "mayo@mistral.ai"
+
+          git remote add public https://github.com/mistralai/platform-docs-public.git
+          git remote update
+          git status
+
+          git merge public/main --no-commit --no-ff --no-edit --allow-unrelated-histories
+
+          if ! git diff-index --cached --quiet HEAD; then
+            git commit -m "Update from public repo"
+            git push origin "${{ github.ref }}"
+          else
+            echo "No changes to apply"
+          fi
+
+      - name: Push to public repo
+        env:
+          GITHUB_TOKEN: ${{ steps.warden.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          git checkout public/main
+          git checkout -b "doc/${{ github.ref_name }}"
+
+          echo "${{ github.ref_name }}" > version.txt
+
+          git add .
+          git commit -m "Bump version file"
+
+          git diff "doc/${{ github.ref_name }}" "${{ github.ref_name }}" --binary --ignore-submodules=none -- . ':!.github' > changes.diff
+          git apply changes.diff
+
+          git add .
+          git commit -m "Update version to ${{ github.ref_name }}"
+
+          git push public "doc/${{ github.ref_name }}"
+
+          gh pr create \
+            --title "Update docs to ${{ github.ref_name }}" \
+            --body "This PR was automatically created by a GitHub Action" \
+            --base main \
+            --head "doc/${{ github.ref_name }}" \
+            --repo mistralai/platform-docs-public

--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -5,11 +5,43 @@ on:
 jobs:
   update-submodule:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
+      - name: Request public docs Warden token
+        id: warden
+        env:
+          X_PRIVATE_ACCESS_STAGING: ${{ secrets.X_PRIVATE_ACCESS_STAGING }}
+        run: |
+          set -euo pipefail
+
+          OIDC_TOKEN=$(curl --fail --silent --show-error --location \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://warden.globalaegis.net" \
+            | jq -er '.value')
+
+          WARDEN_HEADERS=(
+            -H "Authorization: Bearer $OIDC_TOKEN"
+            -H "Content-Type: application/json"
+            -H "Accept: text/plain"
+          )
+          if [[ -n "${X_PRIVATE_ACCESS_STAGING:-}" ]]; then
+            WARDEN_HEADERS+=( -H "X-Private-Access: $X_PRIVATE_ACCESS_STAGING" )
+          fi
+
+          TOKEN=$(curl --fail-with-body --silent --show-error --location \
+            --request POST https://warden.globalaegis.net/token \
+            "${WARDEN_HEADERS[@]}" \
+            --data '{"type":"github","repository":"platform-docs-public","perms":["contents:write","pull_requests:write"]}')
+
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
       - name: Checkout Repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
-          token: ${{ secrets.PUBLIC_DOCS_WRITE_TOKEN }}
+          token: ${{ steps.warden.outputs.token }}
           submodules: true
 
       - name: Set Git Config
@@ -29,7 +61,7 @@ jobs:
       - name: Check if PR Exists
         id: check_pr
         env:
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_DOCS_WRITE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.warden.outputs.token }}
         run: |
           PR_COUNT=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             "https://api.github.com/repos/${{ github.repository }}/pulls?head=update-cookbook-submodule&state=open" | jq '. | length')
@@ -69,7 +101,7 @@ jobs:
       - name: Create Pull Request via API
         if: steps.check_pr.outputs.pr_exists == 'false'
         env:
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_DOCS_WRITE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.warden.outputs.token }}
         run: |
           PR_TITLE="Update cookbook submodule to latest version"
           PR_BODY="This PR updates the cookbook submodule to the latest version."


### PR DESCRIPTION
## Summary

Replace `PUBLIC_DOCS_WRITE_TOKEN` with short-lived Warden GitHub App tokens.

- PR-producing workflows request only `platform-docs-public: contents:write, pull_requests:write`.
- Branch cleanup uses the ephemeral built-in GitHub token with `contents:write`.
- The tag-triggered workflow executes a reusable workflow pinned to `main`, providing a stable Warden trust boundary.

## Dependencies and rollout

- Requires mistralai/vortex#75223 to deploy the Warden policy.
- Requires `X_PRIVATE_ACCESS_STAGING` to be made available to this repository.
- After policy deployment and successful workflow smoke tests, delete `PUBLIC_DOCS_WRITE_TOKEN` from this repository.

## Validation

- All modified workflows parse as YAML.
- actionlint passes for all modified workflows.
- No `PUBLIC_DOCS_WRITE_TOKEN` references remain.
- `git diff --check` passes.
